### PR TITLE
Implement the connecting animation in Compose

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,9 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
-kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 

--- a/mediarouter-compose/build.gradle.kts
+++ b/mediarouter-compose/build.gradle.kts
@@ -72,6 +72,10 @@ dependencies {
     implementation(libs.androidx.mediarouter)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    implementation(platform(libs.kotlin.bom))
+    debugImplementation(libs.kotlin.reflect) {
+        because("it is needed to dynamically generate Icons previews")
+    }
 
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.ext.junit)

--- a/mediarouter-compose/build.gradle.kts
+++ b/mediarouter-compose/build.gradle.kts
@@ -73,9 +73,6 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
     implementation(platform(libs.kotlin.bom))
-    debugImplementation(libs.kotlin.reflect) {
-        because("it is needed to dynamically generate Icons previews")
-    }
 
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.ext.junit)

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastIcon.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastIcon.kt
@@ -1,0 +1,309 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.InfiniteTransition
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PointMode
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.atan
+
+@Composable
+@Suppress("LongMethod")
+internal fun CastIcon(
+    state: CastConnectionState,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    color: Color = LocalContentColor.current,
+    strokeWidth: Dp = 2.dp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val radiusDeltaMiddleToEnd by infiniteTransition.animateFloat(
+        state = state,
+        from = 0f,
+        to = 4f,
+        durationMillis = ConnectingAnimationDuration / 2,
+    )
+    val radiusDeltaStartToEnd by infiniteTransition.animateFloat(
+        state = state,
+        from = 0f,
+        to = 8f,
+        durationMillis = ConnectingAnimationDuration,
+    )
+    val radiusDeltaStartToMiddle by infiniteTransition.animateFloat(
+        state = state,
+        from = 0f,
+        to = 4f,
+        durationMillis = ConnectingAnimationDuration / 2,
+        delayMillis = ConnectingAnimationDuration / 2,
+    )
+    val connectedRectColor by animateColorAsState(
+        targetValue = if (state == CastConnectionState.Connected) color else Color.Transparent,
+    )
+    val strokeWidthPx = with(LocalDensity.current) {
+        strokeWidth.toPx()
+    }
+
+    Canvas(
+        modifier = modifier
+            .size(24.dp)
+            .aspectRatio(9f / 7f)
+            .then(
+                if (contentDescription != null) {
+                    Modifier.semantics {
+                        this.contentDescription = contentDescription
+                        this.role = Role.Image
+                    }
+                } else {
+                    Modifier
+                }
+            ),
+    ) {
+        val arcUnitWidth = size.height * ArcHeightRatio / ArcUnitCount
+        val arcCenter = Offset(0f, size.height)
+
+        drawBorder(color, strokeWidthPx)
+
+        drawCornerArc(color, arcCenter, radius = 3f * arcUnitWidth)
+
+        drawArc(
+            color = color,
+            center = arcCenter,
+            radius1 = (7f + radiusDeltaMiddleToEnd) * arcUnitWidth,
+            radius2 = (5f + radiusDeltaMiddleToEnd) * arcUnitWidth,
+        )
+
+        drawArc(
+            color = color,
+            center = arcCenter,
+            radius1 = 11f * arcUnitWidth,
+            radius2 = 9f * arcUnitWidth,
+        )
+
+        if (state == CastConnectionState.Connected) {
+            drawConnectedRect(
+                color = connectedRectColor,
+                center = arcCenter,
+                strokeWidth = strokeWidthPx,
+            )
+        } else if (state == CastConnectionState.Connecting) {
+            drawArc(
+                color = color,
+                center = arcCenter,
+                radius1 = (3f + radiusDeltaStartToEnd) * arcUnitWidth,
+                radius2 = (1f + radiusDeltaStartToEnd) * arcUnitWidth,
+            )
+
+            drawArc(
+                color = color,
+                center = arcCenter,
+                radius1 = (3f + radiusDeltaStartToMiddle) * arcUnitWidth,
+                radius2 = (1f + radiusDeltaStartToMiddle) * arcUnitWidth,
+            )
+        }
+    }
+}
+
+internal enum class CastConnectionState {
+    Connected,
+    Connecting,
+    Disconnected,
+}
+
+@Composable
+private fun InfiniteTransition.animateFloat(
+    state: CastConnectionState,
+    from: Float,
+    to: Float,
+    durationMillis: Int,
+    delayMillis: Int = 0,
+): State<Float> {
+    return if (state == CastConnectionState.Connecting) {
+        animateFloat(
+            initialValue = from,
+            targetValue = to,
+            animationSpec = infiniteRepeatable(
+                animation = tween(
+                    durationMillis = durationMillis,
+                    delayMillis = delayMillis,
+                    easing = LinearEasing,
+                )
+            ),
+        )
+    } else {
+        remember(from) {
+            mutableFloatStateOf(from)
+        }
+    }
+}
+
+private fun DrawScope.drawBorder(
+    color: Color,
+    strokeWidth: Float,
+) {
+    val width = size.width
+    val height = size.height
+    val arcsSize = height * ArcHeightRatio
+    val halfStrokeWidth = strokeWidth / 2f
+    val cornerTopLeft = Offset(halfStrokeWidth, halfStrokeWidth)
+    val cornerTopRight = Offset(width - halfStrokeWidth, halfStrokeWidth)
+    val cornerBottomRight = Offset(width - halfStrokeWidth, height - halfStrokeWidth)
+    val borderPoints = listOf(
+        Offset(halfStrokeWidth, height - arcsSize), cornerTopLeft,
+        cornerTopLeft, cornerTopRight,
+        cornerTopRight, cornerBottomRight,
+        cornerBottomRight, Offset(arcsSize, height - halfStrokeWidth),
+    )
+
+    drawPoints(
+        points = borderPoints,
+        pointMode = PointMode.Lines,
+        color = color,
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Square,
+    )
+}
+
+private fun DrawScope.drawCornerArc(
+    color: Color,
+    center: Offset,
+    radius: Float,
+) {
+    val path = Path()
+    path.moveTo(center.x, center.y)
+    path.arcTo(
+        rect = Rect(center, radius),
+        startAngleDegrees = -90f,
+        sweepAngleDegrees = 90f,
+        forceMoveTo = false,
+    )
+    path.close()
+
+    drawPath(path, color)
+}
+
+private fun DrawScope.drawArc(
+    color: Color,
+    center: Offset,
+    radius1: Float,
+    radius2: Float,
+) {
+    val path = Path()
+    path.arcTo(
+        rect = Rect(
+            center = center,
+            radius = radius1,
+        ),
+        startAngleDegrees = 0f,
+        sweepAngleDegrees = -90f,
+        forceMoveTo = false,
+    )
+    path.arcTo(
+        rect = Rect(
+            center = center,
+            radius = radius2,
+        ),
+        startAngleDegrees = -90f,
+        sweepAngleDegrees = 90f,
+        forceMoveTo = false,
+    )
+    path.close()
+
+    drawPath(path, color)
+}
+
+private fun DrawScope.drawConnectedRect(
+    color: Color,
+    center: Offset,
+    strokeWidth: Float,
+) {
+    val width = size.width
+    val height = size.height
+    val arcsSize = (ArcUnitCount - 1f) * height * ArcHeightRatio / ArcUnitCount
+    val doubleStrokeWidth = 2f * strokeWidth
+    val startAngle = -atan(doubleStrokeWidth / arcsSize)
+    val sweepAngle = -(PI.toFloat() / 2f + 2f * startAngle)
+    val path = Path()
+    path.moveTo(doubleStrokeWidth, height - arcsSize)
+    path.lineTo(doubleStrokeWidth, doubleStrokeWidth)
+    path.lineTo(width - doubleStrokeWidth, doubleStrokeWidth)
+    path.lineTo(width - doubleStrokeWidth, height - doubleStrokeWidth)
+    path.lineTo(arcsSize, height - doubleStrokeWidth)
+    path.arcToRad(
+        rect = Rect(
+            center = center,
+            radius = arcsSize,
+        ),
+        startAngleRadians = startAngle,
+        sweepAngleRadians = sweepAngle,
+        forceMoveTo = false,
+    )
+    path.close()
+
+    drawPath(path, color)
+}
+
+@Preview
+@Composable
+private fun CastIconConnectedPreview() {
+    MaterialTheme {
+        CastIcon(
+            state = CastConnectionState.Connected,
+            contentDescription = null,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CastIconConnectingPreview() {
+    MaterialTheme {
+        CastIcon(
+            state = CastConnectionState.Connecting,
+            contentDescription = null,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CastIconDisconnectedPreview() {
+    MaterialTheme {
+        CastIcon(
+            state = CastConnectionState.Disconnected,
+            contentDescription = null,
+        )
+    }
+}
+
+private const val ArcHeightRatio = 0.75f
+private const val ArcUnitCount = 14
+private const val ConnectingAnimationDuration = 1200

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
@@ -86,52 +86,6 @@ internal object Icons {
         }
     }
 
-    internal val CastConnected: ImageVector by lazy {
-        materialIcon(name = "Filled.CastConnected") {
-            materialPath {
-                moveTo(1.0f, 18.0f)
-                verticalLineToRelative(3.0f)
-                horizontalLineToRelative(3.0f)
-                curveToRelative(0.0f, -1.66f, -1.34f, -3.0f, -3.0f, -3.0f)
-                close()
-                moveTo(1.0f, 14.0f)
-                verticalLineToRelative(2.0f)
-                curveToRelative(2.76f, 0.0f, 5.0f, 2.24f, 5.0f, 5.0f)
-                horizontalLineToRelative(2.0f)
-                curveToRelative(0.0f, -3.87f, -3.13f, -7.0f, -7.0f, -7.0f)
-                close()
-                moveTo(19.0f, 7.0f)
-                lineTo(5.0f, 7.0f)
-                verticalLineToRelative(1.63f)
-                curveToRelative(3.96f, 1.28f, 7.09f, 4.41f, 8.37f, 8.37f)
-                lineTo(19.0f, 17.0f)
-                lineTo(19.0f, 7.0f)
-                close()
-                moveTo(1.0f, 10.0f)
-                verticalLineToRelative(2.0f)
-                curveToRelative(4.97f, 0.0f, 9.0f, 4.03f, 9.0f, 9.0f)
-                horizontalLineToRelative(2.0f)
-                curveToRelative(0.0f, -6.08f, -4.93f, -11.0f, -11.0f, -11.0f)
-                close()
-                moveTo(21.0f, 3.0f)
-                lineTo(3.0f, 3.0f)
-                curveToRelative(-1.1f, 0.0f, -2.0f, 0.9f, -2.0f, 2.0f)
-                verticalLineToRelative(3.0f)
-                horizontalLineToRelative(2.0f)
-                lineTo(3.0f, 5.0f)
-                horizontalLineToRelative(18.0f)
-                verticalLineToRelative(14.0f)
-                horizontalLineToRelative(-7.0f)
-                verticalLineToRelative(2.0f)
-                horizontalLineToRelative(7.0f)
-                curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
-                lineTo(23.0f, 5.0f)
-                curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
-                close()
-            }
-        }
-    }
-
     internal val Close: ImageVector by lazy {
         materialIcon(name = "Filled.Close") {
             materialPath {
@@ -147,54 +101,6 @@ internal object Icons {
                 lineTo(17.59f, 19.0f)
                 lineTo(19.0f, 17.59f)
                 lineTo(13.41f, 12.0f)
-                close()
-            }
-        }
-    }
-
-    internal val Downloading: ImageVector by lazy {
-        materialIcon(name = "Filled.Downloading") {
-            materialPath {
-                moveTo(18.32f, 4.26f)
-                curveTo(16.84f, 3.05f, 15.01f, 2.25f, 13.0f, 2.05f)
-                verticalLineToRelative(2.02f)
-                curveToRelative(1.46f, 0.18f, 2.79f, 0.76f, 3.9f, 1.62f)
-                lineTo(18.32f, 4.26f)
-                close()
-                moveTo(19.93f, 11.0f)
-                horizontalLineToRelative(2.02f)
-                curveToRelative(-0.2f, -2.01f, -1.0f, -3.84f, -2.21f, -5.32f)
-                lineTo(18.31f, 7.1f)
-                curveTo(19.17f, 8.21f, 19.75f, 9.54f, 19.93f, 11.0f)
-                close()
-                moveTo(18.31f, 16.9f)
-                lineToRelative(1.43f, 1.43f)
-                curveToRelative(1.21f, -1.48f, 2.01f, -3.32f, 2.21f, -5.32f)
-                horizontalLineToRelative(-2.02f)
-                curveTo(19.75f, 14.46f, 19.17f, 15.79f, 18.31f, 16.9f)
-                close()
-                moveTo(13.0f, 19.93f)
-                verticalLineToRelative(2.02f)
-                curveToRelative(2.01f, -0.2f, 3.84f, -1.0f, 5.32f, -2.21f)
-                lineToRelative(-1.43f, -1.43f)
-                curveTo(15.79f, 19.17f, 14.46f, 19.75f, 13.0f, 19.93f)
-                close()
-                moveTo(13.0f, 12.0f)
-                verticalLineTo(7.0f)
-                horizontalLineToRelative(-2.0f)
-                verticalLineToRelative(5.0f)
-                horizontalLineTo(7.0f)
-                lineToRelative(5.0f, 5.0f)
-                lineToRelative(5.0f, -5.0f)
-                horizontalLineTo(13.0f)
-                close()
-                moveTo(11.0f, 19.93f)
-                verticalLineToRelative(2.02f)
-                curveToRelative(-5.05f, -0.5f, -9.0f, -4.76f, -9.0f, -9.95f)
-                reflectiveCurveToRelative(3.95f, -9.45f, 9.0f, -9.95f)
-                verticalLineToRelative(2.02f)
-                curveTo(7.05f, 4.56f, 4.0f, 7.92f, 4.0f, 12.0f)
-                reflectiveCurveTo(7.05f, 19.44f, 11.0f, 19.93f)
                 close()
             }
         }

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
@@ -1,5 +1,14 @@
 package ch.srgssr.androidx.mediarouter.compose
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
@@ -9,7 +18,11 @@ import androidx.compose.ui.graphics.vector.DefaultFillType
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.PathBuilder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import kotlin.reflect.full.declaredMemberProperties
 
 // The content of this file comes from the material-icons and material-icons-extended artefacts.
 // We copied the necessary content to avoid a dependency on these modules for a couple of icons.
@@ -395,7 +408,7 @@ private inline fun ImageVector.Builder.materialPath(
     fillAlpha: Float = 1f,
     strokeAlpha: Float = 1f,
     pathFillType: PathFillType = DefaultFillType,
-    pathBuilder: PathBuilder.() -> Unit
+    pathBuilder: PathBuilder.() -> Unit,
 ): ImageVector.Builder {
     return path(
         fill = SolidColor(Color.Black),
@@ -412,3 +425,35 @@ private inline fun ImageVector.Builder.materialPath(
 }
 
 private const val MaterialIconDimension = 24f
+
+private class IconParameterProvider : PreviewParameterProvider<Pair<String, ImageVector>> {
+    override val values: Sequence<Pair<String, ImageVector>>
+        get() = Icons::class.declaredMemberProperties
+            .asSequence()
+            .filter { it.returnType.classifier == ImageVector::class }
+            .map { it.name to it.get(Icons) as ImageVector }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun IconPreview(
+    @PreviewParameter(IconParameterProvider::class) imageData: Pair<String, ImageVector>,
+) {
+    MaterialTheme {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = imageData.second,
+                contentDescription = null,
+            )
+
+            Text(
+                text = imageData.first,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import kotlin.reflect.full.declaredMemberProperties
 
 // The content of this file comes from the material-icons and material-icons-extended artefacts.
 // We copied the necessary content to avoid a dependency on these modules for a couple of icons.
@@ -334,10 +333,17 @@ private const val MaterialIconDimension = 24f
 
 private class IconParameterProvider : PreviewParameterProvider<Pair<String, ImageVector>> {
     override val values: Sequence<Pair<String, ImageVector>>
-        get() = Icons::class.declaredMemberProperties
+        get() = Icons::class.java.declaredMethods
             .asSequence()
-            .filter { it.returnType.classifier == ImageVector::class }
-            .map { it.name to it.get(Icons) as ImageVector }
+            .filter { it.returnType == ImageVector::class.java }
+            .map {
+                val name = it.name
+                    .removePrefix("get")
+                    .removeSuffix("\$mediarouter_compose_debug")
+                val imageVector = it.invoke(Icons) as ImageVector
+
+                name to imageVector
+            }
 }
 
 @Composable


### PR DESCRIPTION
## Description

This PR implements a `CastIcon` composable that supports all the connection states (disconnected, connecting, and connected).

## Changes made

- Updated the `Icons` file to dynamically generate a preview for each icon.
- Created a `CastIcon` composable.
- Updated the `MediaRouteButton` to use the new `CastIcon`.