### PR TITLE
Extract the logic from `MediaRouteChooserDialog`

### DIFF
--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModel.kt
@@ -1,0 +1,166 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.app.Application
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.mediarouter.R
+import androidx.mediarouter.media.MediaRouteSelector
+import androidx.mediarouter.media.MediaRouter
+import androidx.mediarouter.media.MediaRouter.RouteInfo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.flow.update
+import kotlin.time.Duration.Companion.seconds
+
+class MediaRouteChooserDialogViewModel(
+    private val application: Application,
+    private val routeSelector: MediaRouteSelector,
+) : AndroidViewModel(application) {
+    enum class ChooserState {
+        FindingDevices,
+        NoDevicesNoWifiHint,
+        NoRoutes,
+        ShowingRoutes;
+
+        @VisibleForTesting
+        internal fun title(context: Context): String {
+            val titleRes = when (this) {
+                FindingDevices,
+                NoDevicesNoWifiHint,
+                ShowingRoutes -> R.string.mr_chooser_title
+
+                NoRoutes -> R.string.mr_chooser_zero_routes_found_title
+            }
+
+            return context.getString(titleRes)
+        }
+
+        @VisibleForTesting
+        internal fun confirmLabel(context: Context): String? {
+            return when (this) {
+                FindingDevices,
+                NoDevicesNoWifiHint,
+                ShowingRoutes -> null
+
+                NoRoutes -> context.getString(android.R.string.ok)
+            }
+        }
+    }
+
+    private val mediaRouterCallback = MediaRouterCallback()
+    private val router = MediaRouter.getInstance(application)
+    private val screenOffReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == Intent.ACTION_SCREEN_OFF) {
+                hideDialog()
+            }
+        }
+    }
+
+    private val routerUpdates = MutableStateFlow(0)
+    private val _showDialog = MutableStateFlow(true)
+    private val _routes = routerUpdates.map {
+        router.routes
+            .filter { route ->
+                !route.isDefaultOrBluetooth &&
+                        route.isEnabled &&
+                        route.matchesSelector(routeSelector)
+            }
+            .sortedBy(RouteInfo::getName)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val _chooserState = _routes.transformLatest { routes ->
+        if (routes.isEmpty()) {
+            emit(ChooserState.FindingDevices)
+
+            delay(5.seconds)
+
+            emit(ChooserState.NoDevicesNoWifiHint)
+
+            delay(15.seconds)
+
+            emit(ChooserState.NoRoutes)
+
+            router.removeCallback(mediaRouterCallback)
+        } else {
+            emit(ChooserState.ShowingRoutes)
+        }
+    }
+
+    val showDialog = _showDialog.asStateFlow()
+    val routes = _routes.stateIn(viewModelScope, WhileSubscribed(), emptyList())
+    val chooserState = _chooserState
+        .stateIn(viewModelScope, WhileSubscribed(), ChooserState.FindingDevices)
+    val title = _chooserState.map { it.title(application) }
+        .stateIn(viewModelScope, WhileSubscribed(), "")
+    val confirmButtonLabel = _chooserState.map { it.confirmLabel(application) }
+        .stateIn(viewModelScope, WhileSubscribed(), null)
+
+    init {
+        router.addCallback(
+            routeSelector,
+            mediaRouterCallback,
+            MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN,
+        )
+
+        application.registerReceiver(screenOffReceiver, IntentFilter(Intent.ACTION_SCREEN_OFF))
+    }
+
+    fun hideDialog() {
+        _showDialog.update { false }
+    }
+
+    override fun onCleared() {
+        _showDialog.update { true }
+        router.removeCallback(mediaRouterCallback)
+        application.unregisterReceiver(screenOffReceiver)
+    }
+
+    class Factory(private val routeSelector: MediaRouteSelector) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = checkNotNull(extras[APPLICATION_KEY])
+
+            @Suppress("UNCHECKED_CAST")
+            return MediaRouteChooserDialogViewModel(application, routeSelector) as T
+        }
+    }
+
+    private inner class MediaRouterCallback : MediaRouter.Callback() {
+        override fun onRouteAdded(router: MediaRouter, route: RouteInfo) {
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onRouteRemoved(router: MediaRouter, route: RouteInfo) {
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onRouteChanged(router: MediaRouter, route: RouteInfo) {
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onRouteSelected(
+            router: MediaRouter,
+            selectedRoute: RouteInfo,
+            reason: Int,
+            requestedRoute: RouteInfo,
+        ) {
+            routerUpdates.update { it + 1 }
+        }
+    }
+}

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
@@ -8,12 +8,9 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.MutableCreationExtras
 import androidx.mediarouter.media.MediaControlIntent
-import androidx.mediarouter.media.MediaRouteDescriptor
 import androidx.mediarouter.media.MediaRouteProvider
-import androidx.mediarouter.media.MediaRouteProviderDescriptor
 import androidx.mediarouter.media.MediaRouteSelector
 import androidx.mediarouter.media.MediaRouter
-import androidx.mediarouter.media.MediaRouter.RouteInfo
 import androidx.mediarouter.media.MediaRouterParams
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -41,36 +38,13 @@ class MediaRouteButtonViewModelTest {
             .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
             .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
             .build()
-        val providerDescriptor = MediaRouteProviderDescriptor.Builder()
-            .addRoute(
-                MediaRouteDescriptor.Builder("disconnected_route", "Disconnected route")
-                    .setConnectionState(RouteInfo.CONNECTION_STATE_DISCONNECTED)
-                    .build()
-            )
-            .addRoute(
-                MediaRouteDescriptor.Builder("connecting_route", "Connecting route")
-                    .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTING)
-                    .build()
-            )
-            .addRoute(
-                MediaRouteDescriptor.Builder("connected_route", "Connected route")
-                    .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTED)
-                    .build()
-            )
-            .addRoute(
-                MediaRouteDescriptor.Builder("invalid_state_route", "Invalid state route")
-                    .setConnectionState(Int.MAX_VALUE)
-                    .build()
-            )
-            .build()
 
         context = ApplicationProvider.getApplicationContext<Application>()
 
         // Trigger static initialization inside MediaRouter
         context.getSystemService<android.media.MediaRouter>()
 
-        provider = object : MediaRouteProvider(context) {}
-        provider.descriptor = providerDescriptor
+        provider = TestMediaRouteProvider(context)
 
         router = MediaRouter.getInstance(context)
         router.addProvider(provider)

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
@@ -1,0 +1,196 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.app.Application
+import android.os.Looper
+import androidx.core.content.getSystemService
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.mediarouter.R
+import androidx.mediarouter.media.MediaControlIntent
+import androidx.mediarouter.media.MediaRouteProvider
+import androidx.mediarouter.media.MediaRouteSelector
+import androidx.mediarouter.media.MediaRouter
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import app.cash.turbine.test
+import ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel.ChooserState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class MediaRouteChooserDialogViewModelTest {
+    private lateinit var context: Application
+    private lateinit var provider: MediaRouteProvider
+    private lateinit var router: MediaRouter
+    private lateinit var viewModel: MediaRouteChooserDialogViewModel
+
+    @BeforeTest
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun before() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+        val routeSelector = MediaRouteSelector.Builder()
+            .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
+            .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
+            .build()
+
+        context = ApplicationProvider.getApplicationContext<Application>()
+
+        // Trigger static initialization inside MediaRouter
+        context.getSystemService<android.media.MediaRouter>()
+
+        provider = TestMediaRouteProvider(context)
+
+        router = MediaRouter.getInstance(context)
+
+        viewModel = MediaRouteChooserDialogViewModel(context, routeSelector)
+    }
+
+    @AfterTest
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun after() {
+        router.removeProvider(provider)
+
+        shadowOf(Looper.getMainLooper()).idle()
+
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `check the default values`() = runTest {
+        viewModel.showDialog.test {
+            assertTrue(awaitItem())
+        }
+
+        viewModel.routes.test {
+            assertEquals(emptyList(), awaitItem())
+        }
+
+        viewModel.chooserState.test {
+            assertEquals(ChooserState.FindingDevices, awaitItem())
+        }
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_chooser_title), awaitItem())
+        }
+
+        viewModel.confirmButtonLabel.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `hide dialog`() = runTest {
+        router.addProvider(provider)
+
+        viewModel.showDialog.test {
+            assertTrue(awaitItem())
+
+            viewModel.hideDialog()
+
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check that the route are filtered and sorted alphabetically`() = runTest {
+        router.addProvider(provider)
+
+        viewModel.routes.test {
+            assertEquals(
+                listOf("Connected route", "Disconnected route"),
+                awaitItem().map { it.name },
+            )
+        }
+    }
+
+    @Test
+    fun `check that the chooser state moves to ShowingRoutes when there are routes available`() {
+        runTest {
+            viewModel.chooserState.test {
+                assertEquals(ChooserState.FindingDevices, awaitItem())
+
+                router.addProvider(provider)
+                InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+                assertEquals(ChooserState.ShowingRoutes, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun `check that the chooser state is updated periodically when no routes are available`() {
+        runTest {
+            viewModel.chooserState.test {
+                assertEquals(ChooserState.FindingDevices, awaitItem())
+                assertEquals(ChooserState.NoDevicesNoWifiHint, awaitItem())
+                assertEquals(ChooserState.NoRoutes, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun `check the title based on the chooser state`() {
+        assertEquals(
+            expected = context.getString(R.string.mr_chooser_title),
+            actual = ChooserState.FindingDevices.title(context),
+        )
+        assertEquals(
+            expected = context.getString(R.string.mr_chooser_title),
+            actual = ChooserState.NoDevicesNoWifiHint.title(context),
+        )
+        assertEquals(
+            expected = context.getString(R.string.mr_chooser_zero_routes_found_title),
+            actual = ChooserState.NoRoutes.title(context),
+        )
+        assertEquals(
+            expected = context.getString(R.string.mr_chooser_title),
+            actual = ChooserState.ShowingRoutes.title(context),
+        )
+    }
+
+    @Test
+    fun `check the confirm label based on the chooser state`() {
+        assertNull(ChooserState.FindingDevices.confirmLabel(context))
+        assertNull(ChooserState.NoDevicesNoWifiHint.confirmLabel(context))
+        assertEquals(
+            expected = context.getString(android.R.string.ok),
+            actual = ChooserState.NoRoutes.confirmLabel(context),
+        )
+        assertNull(ChooserState.ShowingRoutes.confirmLabel(context))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `ViewModel factory fails to create a ViewModel without a Context`() {
+        MediaRouteChooserDialogViewModel.Factory(MediaRouteSelector.EMPTY)
+            .create(ViewModel::class.java, CreationExtras.Empty)
+    }
+
+    @Test
+    fun `ViewModel factory creates an instance of MediaRouteChooserDialogViewModel`() {
+        val creationExtras = MutableCreationExtras()
+        creationExtras[APPLICATION_KEY] = context
+
+        val viewModel = MediaRouteChooserDialogViewModel.Factory(MediaRouteSelector.EMPTY)
+            .create(ViewModel::class.java, creationExtras)
+
+        assertIs<MediaRouteChooserDialogViewModel>(viewModel)
+    }
+}

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
@@ -1,0 +1,51 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.content.Context
+import android.content.IntentFilter
+import androidx.mediarouter.media.MediaControlIntent
+import androidx.mediarouter.media.MediaRouteDescriptor
+import androidx.mediarouter.media.MediaRouteProvider
+import androidx.mediarouter.media.MediaRouteProviderDescriptor
+import androidx.mediarouter.media.MediaRouter.RouteInfo
+
+class TestMediaRouteProvider(context: Context) : MediaRouteProvider(context) {
+    init {
+        val intentFilterAudio = IntentFilter()
+        intentFilterAudio.addCategory(MediaControlIntent.CATEGORY_LIVE_AUDIO)
+        val intentFilterVideo = IntentFilter()
+        intentFilterVideo.addCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
+
+        descriptor = MediaRouteProviderDescriptor.Builder()
+            .addRoute(
+                MediaRouteDescriptor.Builder("disconnected_route", "Disconnected route")
+                    .setConnectionState(RouteInfo.CONNECTION_STATE_DISCONNECTED)
+                    .addControlFilter(intentFilterVideo)
+                    .build()
+            )
+            .addRoute(
+                MediaRouteDescriptor.Builder("connecting_route", "Connecting route")
+                    .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTING)
+                    .addControlFilter(intentFilterAudio)
+                    .build()
+            )
+            .addRoute(
+                MediaRouteDescriptor.Builder("connected_route", "Connected route")
+                    .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTED)
+                    .addControlFilter(intentFilterVideo)
+                    .build()
+            )
+            .addRoute(
+                MediaRouteDescriptor.Builder("invalid_state_route", "Invalid state route")
+                    .setConnectionState(Int.MAX_VALUE)
+                    .addControlFilter(intentFilterAudio)
+                    .build()
+            )
+            .addRoute(
+                MediaRouteDescriptor.Builder("disabled_route", "Disabled route")
+                    .setEnabled(false)
+                    .addControlFilter(intentFilterVideo)
+                    .build()
+            )
+            .build()
+    }
+}


### PR DESCRIPTION
## Description

This PR extracts all the logic from `MediaRouteChooserDialog` into a dedicated `ViewModel`. This greatly simplifies the Compose code and eases testing of the logic.

## Changes made

- Move logic from `MediaRouteChooserDialog` to `MediaRouteChooserDialogViewModel`.
- Create a `TestMediaRouteProvider` class to provide fake routes.
- Add tests to `MediaRouteChooserDialogViewModel`.