### PR TITLE
Extract the logic from `MediaRouteControllerDialog`

### DIFF
--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionState.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionState.kt
@@ -3,7 +3,7 @@ package ch.srgssr.androidx.mediarouter.compose
 import androidx.annotation.StringRes
 import androidx.mediarouter.R
 
-enum class CastConnectionState(@StringRes val contentDescriptionRes: Int) {
+internal enum class CastConnectionState(@StringRes val contentDescriptionRes: Int) {
     Connected(R.string.mr_cast_button_connected),
     Connecting(R.string.mr_cast_button_connecting),
     Disconnected(R.string.mr_cast_button_disconnected),

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
@@ -57,6 +57,7 @@ fun MediaRouteButton(
     mediaRouteDynamicChooserDialog: @Composable () -> Unit = {}, // TODO
     mediaRouteControllerDialog: @Composable (onDismissRequest: () -> Unit) -> Unit = { onDismissRequest ->
         MediaRouteControllerDialog(
+            routeSelector = routeSelector,
             onDismissRequest = onDismissRequest,
         )
     },

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
-class MediaRouteButtonViewModel(
+internal class MediaRouteButtonViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle,
     private val routeSelector: MediaRouteSelector,

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.update
 import kotlin.time.Duration.Companion.seconds
 
-class MediaRouteChooserDialogViewModel(
+internal class MediaRouteChooserDialogViewModel(
     private val application: Application,
     private val savedStateHandle: SavedStateHandle,
     private val routeSelector: MediaRouteSelector,

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
@@ -99,10 +99,10 @@ fun MediaRouteControllerDialog(
         customControlView = customControlView,
         toggleDeviceGroup = viewModel::toggleDeviceGroup,
         onKeyEvent = viewModel::onKeyEvent,
-        onPlaybackTitleClick = viewModel::onPlaybackTitleClick,
+        onPlaybackTitleClick = viewModel::startSessionActivity,
         onPlaybackIconClick = viewModel::onPlaybackIconClick,
-        onStopCasting = viewModel::onStopCasting,
-        onDisconnect = viewModel::onDisconnect,
+        onStopCasting = viewModel::stopCasting,
+        onDisconnect = viewModel::disconnect,
         onDismissRequest = viewModel::hideDialog,
     )
 }

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
@@ -1,0 +1,275 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.app.Application
+import android.app.PendingIntent
+import android.support.v4.media.MediaDescriptionCompat
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaControllerCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.support.v4.media.session.PlaybackStateCompat.ACTION_PAUSE
+import android.support.v4.media.session.PlaybackStateCompat.ACTION_PLAY
+import android.support.v4.media.session.PlaybackStateCompat.ACTION_PLAY_PAUSE
+import android.support.v4.media.session.PlaybackStateCompat.ACTION_STOP
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.mediarouter.R
+import androidx.mediarouter.media.MediaRouteSelector
+import androidx.mediarouter.media.MediaRouter
+import androidx.mediarouter.media.MediaRouter.RouteInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+class MediaRouteControllerDialogViewModel(
+    private val application: Application,
+    private val savedStateHandle: SavedStateHandle,
+    private val volumeControlEnabled: Boolean,
+) : AndroidViewModel(application) {
+    private var mediaController: MediaControllerCompat? = null
+
+    private val mediaControllerCallback = MediaControllerCallback()
+    private val mediaRouterCallback = MediaRouterCallback()
+    private val router = MediaRouter.getInstance(application)
+    private val isGroupVolumeUxEnabled = MediaRouter.isGroupVolumeUxEnabled()
+
+    private val routerUpdates = MutableStateFlow(0)
+
+    @VisibleForTesting
+    internal val mediaDescription = MutableStateFlow<MediaDescriptionCompat?>(null)
+
+    @VisibleForTesting
+    internal val playbackState = MutableStateFlow<PlaybackStateCompat?>(null)
+    private val _isDeviceGroupExpanded = MutableStateFlow(false)
+    private val _selectedRoute = routerUpdates.map { router.selectedRoute }
+
+    val showDialog = savedStateHandle.getStateFlow(KEY_SHOW_DIALOG, true)
+    val selectedRoute = _selectedRoute
+        .stateIn(viewModelScope, WhileSubscribed(), router.selectedRoute)
+    val isDeviceGroupExpanded: StateFlow<Boolean> = _isDeviceGroupExpanded.asStateFlow()
+
+    val showPlaybackControl =
+        combine(mediaDescription, playbackState) { mediaDescription, playbackState ->
+            mediaDescription != null || playbackState != null
+        }.stateIn(viewModelScope, WhileSubscribed(), false)
+    val showVolumeControl = _selectedRoute.map { selectedRoute ->
+        selectedRoute.volumeHandling == RouteInfo.PLAYBACK_VOLUME_VARIABLE
+                && (isGroupVolumeUxEnabled || !(selectedRoute.isGroup && selectedRoute.memberRoutes.size > 1))
+                && volumeControlEnabled
+    }.stateIn(viewModelScope, WhileSubscribed(), false)
+    val imageModel = mediaDescription.map { mediaDescription ->
+        mediaDescription?.iconBitmap?.takeIf { !it.isRecycled } ?: mediaDescription?.iconUri
+    }.stateIn(viewModelScope, WhileSubscribed(), null)
+
+    val title = combine(
+        mediaDescription,
+        playbackState,
+        _selectedRoute,
+    ) { mediaDescription, playbackState, selectedRoute ->
+        if (selectedRoute.presentationDisplayId != RouteInfo.PRESENTATION_DISPLAY_ID_NONE) {
+            application.getString(R.string.mr_controller_casting_screen)
+        } else if (playbackState == null || playbackState.state == PlaybackStateCompat.STATE_NONE) {
+            application.getString(R.string.mr_controller_no_media_selected)
+        } else if (mediaDescription?.title.isNullOrEmpty() && mediaDescription?.subtitle.isNullOrEmpty()) {
+            application.getString(R.string.mr_controller_no_info_available)
+        } else {
+            mediaDescription.title?.toString()
+        }
+    }.stateIn(viewModelScope, WhileSubscribed(), null)
+    val subtitle = mediaDescription.map { it?.subtitle?.toString() }
+        .stateIn(viewModelScope, WhileSubscribed(), null)
+    val iconInfo = playbackState.map { playbackState ->
+        if (playbackState == null) {
+            return@map null
+        }
+
+        val isPlaying = playbackState.state == PlaybackStateCompat.STATE_BUFFERING
+                || playbackState.state == PlaybackStateCompat.STATE_PLAYING
+
+        val icon: ImageVector
+        val contentDescription: String
+        if (isPlaying && playbackState.isPauseActionSupported) {
+            icon = Icons.Pause
+            contentDescription = application.getString(R.string.mr_controller_pause)
+        } else if (isPlaying && playbackState.isStopActionSupported) {
+            icon = Icons.Stop
+            contentDescription = application.getString(R.string.mr_controller_stop)
+        } else if (!isPlaying && playbackState.isPlayActionSupported) {
+            icon = Icons.PlayArrow
+            contentDescription = application.getString(R.string.mr_controller_play)
+        } else {
+            return@map null
+        }
+
+        icon to contentDescription
+    }.stateIn(viewModelScope, WhileSubscribed(), null)
+
+    init {
+        router.addCallback(
+            MediaRouteSelector.EMPTY,
+            mediaRouterCallback,
+            MediaRouter.CALLBACK_FLAG_UNFILTERED_EVENTS,
+        )
+
+        router.mediaSessionToken?.let { mediaSessionToken ->
+            val mediaController = MediaControllerCompat(application, mediaSessionToken)
+            mediaController.registerCallback(mediaControllerCallback)
+
+            this.mediaController = mediaController
+            mediaDescription.update { mediaController.metadata?.description }
+            playbackState.update { mediaController.playbackState }
+        }
+    }
+
+    fun hideDialog() {
+        savedStateHandle[KEY_SHOW_DIALOG] = false
+    }
+
+    fun toggleDeviceGroup() {
+        _isDeviceGroupExpanded.update { !it }
+    }
+
+    fun onStopCasting() {
+        if (selectedRoute.value.isSelected) {
+            router.unselect(MediaRouter.UNSELECT_REASON_STOPPED)
+        }
+
+        hideDialog()
+    }
+
+    fun onDisconnect() {
+        if (selectedRoute.value.isSelected) {
+            router.unselect(MediaRouter.UNSELECT_REASON_DISCONNECTED)
+        }
+
+        hideDialog()
+    }
+
+    fun onKeyEvent(keyEvent: KeyEvent): Boolean {
+        return if (keyEvent.key == Key.VolumeDown || keyEvent.key == Key.VolumeUp) {
+            val isDeviceGroupExpanded = _isDeviceGroupExpanded.value
+            if (keyEvent.type == KeyEventType.KeyDown && (isGroupVolumeUxEnabled || !isDeviceGroupExpanded)) {
+                val delta = if (keyEvent.key == Key.VolumeDown) -1 else 1
+
+                selectedRoute.value.requestUpdateVolume(delta)
+            }
+
+            true
+        } else {
+            false
+        }
+    }
+
+    fun onPlaybackTitleClick() {
+        mediaController?.sessionActivity?.let { pendingIntent ->
+            try {
+                pendingIntent.send()
+                hideDialog()
+            } catch (exception: PendingIntent.CanceledException) {
+                Log.d(
+                    "MediaRouteController",
+                    "$pendingIntent was not sent, it has been canceled.",
+                    exception,
+                )
+            }
+        }
+    }
+
+    fun onPlaybackIconClick() {
+        val mediaController = mediaController
+        val playbackState = playbackState.value
+
+        if (mediaController != null && playbackState != null) {
+            val isPlaying = playbackState.state == PlaybackStateCompat.STATE_PLAYING
+
+            if (isPlaying && playbackState.isPauseActionSupported) {
+                mediaController.transportControls.pause()
+            } else if (isPlaying && playbackState.isStopActionSupported) {
+                mediaController.transportControls.stop()
+            } else if (!isPlaying && playbackState.isPlayActionSupported) {
+                mediaController.transportControls.play()
+            }
+        }
+    }
+
+    override fun onCleared() {
+        router.removeCallback(mediaRouterCallback)
+        mediaControllerCallback.onSessionDestroyed()
+    }
+
+    private val PlaybackStateCompat.isPlayActionSupported: Boolean
+        get() = actions and (ACTION_PLAY or ACTION_PLAY_PAUSE) != 0L
+
+    private val PlaybackStateCompat.isPauseActionSupported: Boolean
+        get() = actions and (ACTION_PAUSE or ACTION_PLAY_PAUSE) != 0L
+
+    private val PlaybackStateCompat.isStopActionSupported: Boolean
+        get() = actions and ACTION_STOP != 0L
+
+    private companion object {
+        private const val KEY_SHOW_DIALOG = "showDialog"
+    }
+
+    class Factory(private val volumeControlEnabled: Boolean) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = checkNotNull(extras[APPLICATION_KEY])
+            val savedStateHandle = extras.createSavedStateHandle()
+
+            @Suppress("UNCHECKED_CAST")
+            return MediaRouteControllerDialogViewModel(
+                application = application,
+                savedStateHandle = savedStateHandle,
+                volumeControlEnabled = volumeControlEnabled,
+            ) as T
+        }
+    }
+
+    private inner class MediaControllerCallback : MediaControllerCompat.Callback() {
+        override fun onSessionDestroyed() {
+            mediaController?.unregisterCallback(this)
+            mediaController = null
+        }
+
+        override fun onPlaybackStateChanged(state: PlaybackStateCompat?) {
+            playbackState.update { state }
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onMetadataChanged(metadata: MediaMetadataCompat?) {
+            mediaDescription.update { metadata?.description }
+            routerUpdates.update { it + 1 }
+        }
+    }
+
+    private inner class MediaRouterCallback : MediaRouter.Callback() {
+        override fun onRouteUnselected(router: MediaRouter, route: RouteInfo, reason: Int) {
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onRouteChanged(router: MediaRouter, route: RouteInfo) {
+            routerUpdates.update { it + 1 }
+        }
+
+        override fun onRouteVolumeChanged(router: MediaRouter, route: RouteInfo) {
+            routerUpdates.update { it + 1 }
+        }
+    }
+}

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
@@ -91,7 +91,7 @@ internal class MediaRouteControllerDialogViewModel(
         } else if (mediaDescription?.title.isNullOrEmpty() && mediaDescription?.subtitle.isNullOrEmpty()) {
             application.getString(R.string.mr_controller_no_info_available)
         } else {
-            mediaDescription.title?.toString()
+            mediaDescription?.title?.toString()
         }
     }.stateIn(viewModelScope, WhileSubscribed(), null)
     val subtitle = mediaDescription.map { it?.subtitle?.toString() }
@@ -147,7 +147,7 @@ internal class MediaRouteControllerDialogViewModel(
         _isDeviceGroupExpanded.update { !it }
     }
 
-    fun onStopCasting() {
+    fun stopCasting() {
         if (selectedRoute.value.isSelected) {
             router.unselect(MediaRouter.UNSELECT_REASON_STOPPED)
         }
@@ -155,7 +155,7 @@ internal class MediaRouteControllerDialogViewModel(
         hideDialog()
     }
 
-    fun onDisconnect() {
+    fun disconnect() {
         if (selectedRoute.value.isSelected) {
             router.unselect(MediaRouter.UNSELECT_REASON_DISCONNECTED)
         }
@@ -178,7 +178,7 @@ internal class MediaRouteControllerDialogViewModel(
         }
     }
 
-    fun onPlaybackTitleClick() {
+    fun startSessionActivity() {
         mediaController?.sessionActivity?.let { pendingIntent ->
             try {
                 pendingIntent.send()
@@ -194,19 +194,16 @@ internal class MediaRouteControllerDialogViewModel(
     }
 
     fun onPlaybackIconClick() {
-        val mediaController = mediaController
-        val playbackState = playbackState.value
+        val mediaController = mediaController ?: return
+        val playbackState = playbackState.value ?: return
+        val isPlaying = playbackState.state == PlaybackStateCompat.STATE_PLAYING
 
-        if (mediaController != null && playbackState != null) {
-            val isPlaying = playbackState.state == PlaybackStateCompat.STATE_PLAYING
-
-            if (isPlaying && playbackState.isPauseActionSupported) {
-                mediaController.transportControls.pause()
-            } else if (isPlaying && playbackState.isStopActionSupported) {
-                mediaController.transportControls.stop()
-            } else if (!isPlaying && playbackState.isPlayActionSupported) {
-                mediaController.transportControls.play()
-            }
+        if (isPlaying && playbackState.isPauseActionSupported) {
+            mediaController.transportControls.pause()
+        } else if (isPlaying && playbackState.isStopActionSupported) {
+            mediaController.transportControls.stop()
+        } else if (!isPlaying && playbackState.isPlayActionSupported) {
+            mediaController.transportControls.play()
         }
     }
 

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
-class MediaRouteControllerDialogViewModel(
+internal class MediaRouteControllerDialogViewModel(
     private val application: Application,
     private val savedStateHandle: SavedStateHandle,
     private val volumeControlEnabled: Boolean,

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
@@ -118,7 +118,7 @@ class MediaRouteChooserDialogViewModelTest {
 
         viewModel.routes.test {
             assertEquals(
-                listOf("Connected route", "Disconnected route"),
+                listOf("Connected route", "Disconnected route", "Presentation display route"),
                 awaitItem().map { it.name },
             )
         }

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModelTest.kt
@@ -1,0 +1,617 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.app.Application
+import android.graphics.BitmapFactory
+import android.support.v4.media.MediaDescriptionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.view.KeyEvent.ACTION_DOWN
+import android.view.KeyEvent.KEYCODE_A
+import android.view.KeyEvent.KEYCODE_VOLUME_DOWN
+import android.view.KeyEvent.KEYCODE_VOLUME_UP
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.NativeKeyEvent
+import androidx.core.content.getSystemService
+import androidx.core.net.toUri
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.get
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.mediarouter.R
+import androidx.mediarouter.media.MediaRouteProvider
+import androidx.mediarouter.media.MediaRouter
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class MediaRouteControllerDialogViewModelTest {
+    private lateinit var context: Application
+    private lateinit var provider: MediaRouteProvider
+    private lateinit var router: MediaRouter
+    private lateinit var viewModel: MediaRouteControllerDialogViewModel
+
+    @BeforeTest
+    fun before() {
+        context = ApplicationProvider.getApplicationContext<Application>()
+
+        // Trigger static initialization inside MediaRouter
+        context.getSystemService<android.media.MediaRouter>()
+
+        provider = TestMediaRouteProvider(context)
+
+        router = MediaRouter.getInstance(context)
+        router.addProvider(provider)
+        router.selectRoute(router.routes[2])
+
+        viewModel = MediaRouteControllerDialogViewModel(
+            context,
+            SavedStateHandle(),
+            volumeControlEnabled = true
+        )
+    }
+
+    @AfterTest
+    fun after() {
+        router.removeProvider(provider)
+    }
+
+    @Test
+    fun `check the default values`() = runTest {
+        viewModel.showDialog.test {
+            assertTrue(awaitItem())
+        }
+
+        viewModel.selectedRoute.test {
+            assertEquals(router.routes[2], awaitItem())
+        }
+
+        viewModel.isDeviceGroupExpanded.test {
+            assertFalse(awaitItem())
+        }
+
+        viewModel.showPlaybackControl.test {
+            assertFalse(awaitItem())
+        }
+
+        viewModel.showVolumeControl.test {
+            assertFalse(awaitItem())
+        }
+
+        viewModel.imageModel.test {
+            assertNull(awaitItem())
+        }
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_controller_no_media_selected), awaitItem())
+        }
+
+        viewModel.subtitle.test {
+            assertNull(awaitItem())
+        }
+
+        viewModel.iconInfo.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check show playback control with media description`() = runTest {
+        viewModel.mediaDescription.update { MediaDescriptionCompat.Builder().build() }
+
+        viewModel.showPlaybackControl.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check show playback control with playback state`() = runTest {
+        viewModel.playbackState.update { PlaybackStateCompat.Builder().build() }
+
+        viewModel.showPlaybackControl.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check image model with null icon bitmap`() = runTest {
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setIconBitmap(null)
+                .build()
+        }
+
+        viewModel.imageModel.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check image model with recycled icon bitmap`() = runTest {
+        val bitmap = BitmapFactory.decodeByteArray(byteArrayOf(), 0, 0)
+        bitmap.recycle()
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setIconBitmap(bitmap)
+                .build()
+        }
+
+        viewModel.imageModel.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check image model with icon bitmap`() = runTest {
+        val bitmap = BitmapFactory.decodeByteArray(byteArrayOf(), 0, 0)
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setIconBitmap(bitmap)
+                .build()
+        }
+
+        viewModel.imageModel.test {
+            assertEquals(bitmap, awaitItem())
+        }
+    }
+
+    @Test
+    fun `check image model with icon URI`() = runTest {
+        val iconUri = "https://example.com/icon.png".toUri()
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setIconUri(iconUri)
+                .build()
+        }
+
+        viewModel.imageModel.test {
+            assertEquals(iconUri, awaitItem())
+        }
+    }
+
+    @Test
+    fun `check image model with icon bitmap and icon URI`() = runTest {
+        val bitmap = BitmapFactory.decodeByteArray(byteArrayOf(), 0, 0)
+        val iconUri = "https://example.com/icon.png".toUri()
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setIconBitmap(bitmap)
+                .setIconUri(iconUri)
+                .build()
+        }
+
+        viewModel.imageModel.test {
+            assertEquals(bitmap, awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with selected route has a presentation display id`() = runTest {
+        router.selectRoute(router.routes[6])
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_controller_casting_screen), awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with playback state being none`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_NONE, 0L, 0f)
+                .build()
+        }
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_controller_no_media_selected), awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with playback state different than none`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .build()
+        }
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_controller_no_info_available), awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with empty media description`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .build()
+        }
+
+        viewModel.mediaDescription.update { MediaDescriptionCompat.Builder().build() }
+
+        viewModel.title.test {
+            assertEquals(context.getString(R.string.mr_controller_no_info_available), awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with media description containing title only`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .build()
+        }
+
+        val title = "Title"
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setTitle(title)
+                .build()
+        }
+
+        viewModel.title.test {
+            assertEquals(title, awaitItem())
+        }
+    }
+
+    @Test
+    fun `check title with media description containing subtitle only`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .build()
+        }
+
+        val subtitle = "Subtitle"
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setSubtitle(subtitle)
+                .build()
+        }
+
+        viewModel.title.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check subtitle with empty media description`() = runTest {
+        viewModel.mediaDescription.update { MediaDescriptionCompat.Builder().build() }
+
+        viewModel.subtitle.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check subtitle with null subtitle`() = runTest {
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setSubtitle(null)
+                .build()
+        }
+
+        viewModel.subtitle.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check subtitle with empty subtitle`() = runTest {
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setSubtitle("")
+                .build()
+        }
+
+        viewModel.subtitle.test {
+            assertEquals("", awaitItem())
+        }
+    }
+
+    @Test
+    fun `check subtitle with non-empty subtitle`() = runTest {
+        val subtitle = "Subtitle"
+
+        viewModel.mediaDescription.update {
+            MediaDescriptionCompat.Builder()
+                .setSubtitle(subtitle)
+                .build()
+        }
+
+        viewModel.subtitle.test {
+            assertEquals(subtitle, awaitItem())
+        }
+    }
+
+    @Test
+    fun `check icon info while buffering and no capabilities`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_BUFFERING, 0L, 0f)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check icon info while buffering and pause supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_BUFFERING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PAUSE)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Pause, context.getString(R.string.mr_controller_pause)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while buffering and play pause supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_BUFFERING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Pause, context.getString(R.string.mr_controller_pause)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while buffering and stop supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_BUFFERING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_STOP)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Stop, context.getString(R.string.mr_controller_stop)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while playing and no capabilities`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check icon info while playing and pause supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PAUSE)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Pause, context.getString(R.string.mr_controller_pause)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while playing and play pause supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Pause, context.getString(R.string.mr_controller_pause)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while playing and stop supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PLAYING, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_STOP)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.Stop, context.getString(R.string.mr_controller_stop)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while paused and no capabilities`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PAUSED, 0L, 0f)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `check icon info while paused and play supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PAUSED, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PLAY)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.PlayArrow, context.getString(R.string.mr_controller_play)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `check icon info while paused and play pause supported`() = runTest {
+        viewModel.playbackState.update {
+            PlaybackStateCompat.Builder()
+                .setState(PlaybackStateCompat.STATE_PAUSED, 0L, 0f)
+                .setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE)
+                .build()
+        }
+
+        viewModel.iconInfo.test {
+            assertEquals(
+                expected = Pair(Icons.PlayArrow, context.getString(R.string.mr_controller_play)),
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `hide dialog`() = runTest {
+        viewModel.showDialog.test {
+            assertTrue(awaitItem())
+
+            viewModel.hideDialog()
+
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `toggle device group`() = runTest {
+        viewModel.isDeviceGroupExpanded.test {
+            assertFalse(awaitItem())
+
+            viewModel.toggleDeviceGroup()
+
+            assertTrue(awaitItem())
+
+            viewModel.toggleDeviceGroup()
+
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `on stop casting`() = runTest {
+        viewModel.showDialog.test {
+            assertFalse(router.routes[0].isSelected)
+            assertTrue(router.routes[2].isSelected)
+            assertTrue(awaitItem())
+
+            viewModel.onStopCasting()
+
+            assertTrue(router.routes[0].isSelected)
+            assertFalse(router.routes[2].isSelected)
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `on disconnect`() = runTest {
+        viewModel.showDialog.test {
+            assertFalse(router.routes[0].isSelected)
+            assertTrue(router.routes[2].isSelected)
+            assertTrue(awaitItem())
+
+            viewModel.onDisconnect()
+
+            assertTrue(router.routes[0].isSelected)
+            assertFalse(router.routes[2].isSelected)
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `on key event, volume down`() = runTest {
+        val keyEvent = KeyEvent(NativeKeyEvent(ACTION_DOWN, KEYCODE_VOLUME_DOWN))
+
+        assertTrue(viewModel.onKeyEvent(keyEvent))
+    }
+
+    @Test
+    fun `on key event, volume up`() {
+        val keyEvent = KeyEvent(NativeKeyEvent(ACTION_DOWN, KEYCODE_VOLUME_UP))
+
+        assertTrue(viewModel.onKeyEvent(keyEvent))
+    }
+
+    @Test
+    fun `on key event, non-volume key`() {
+        val keyEvent = KeyEvent(NativeKeyEvent(ACTION_DOWN, KEYCODE_A))
+
+        assertFalse(viewModel.onKeyEvent(keyEvent))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `ViewModel factory fails to create a ViewModel without a Context`() {
+        MediaRouteControllerDialogViewModel.Factory(volumeControlEnabled = true)
+            .create(ViewModel::class.java, CreationExtras.Empty)
+    }
+
+    @Test
+    fun `ViewModel factory creates an instance of MediaRouteControllerDialogViewModel`() {
+        Robolectric.buildActivity<ComponentActivity>(ComponentActivity::class.java)
+            .use { activityController ->
+                val viewModel = ViewModelProvider(
+                    owner = activityController.setup().get(),
+                    factory = MediaRouteControllerDialogViewModel.Factory(volumeControlEnabled = true),
+                ).get<ViewModel>()
+
+                assertIs<MediaRouteControllerDialogViewModel>(viewModel)
+            }
+    }
+}

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModelTest.kt
@@ -46,7 +46,7 @@ class MediaRouteControllerDialogViewModelTest {
 
     @BeforeTest
     fun before() {
-        context = ApplicationProvider.getApplicationContext<Application>()
+        context = ApplicationProvider.getApplicationContext()
 
         // Trigger static initialization inside MediaRouter
         context.getSystemService<android.media.MediaRouter>()
@@ -546,13 +546,13 @@ class MediaRouteControllerDialogViewModelTest {
     }
 
     @Test
-    fun `on stop casting`() = runTest {
+    fun `stop casting`() = runTest {
         viewModel.showDialog.test {
             assertFalse(router.routes[0].isSelected)
             assertTrue(router.routes[2].isSelected)
             assertTrue(awaitItem())
 
-            viewModel.onStopCasting()
+            viewModel.stopCasting()
 
             assertTrue(router.routes[0].isSelected)
             assertFalse(router.routes[2].isSelected)
@@ -561,13 +561,13 @@ class MediaRouteControllerDialogViewModelTest {
     }
 
     @Test
-    fun `on disconnect`() = runTest {
+    fun disconnect() = runTest {
         viewModel.showDialog.test {
             assertFalse(router.routes[0].isSelected)
             assertTrue(router.routes[2].isSelected)
             assertTrue(awaitItem())
 
-            viewModel.onDisconnect()
+            viewModel.disconnect()
 
             assertTrue(router.routes[0].isSelected)
             assertFalse(router.routes[2].isSelected)
@@ -604,7 +604,7 @@ class MediaRouteControllerDialogViewModelTest {
 
     @Test
     fun `ViewModel factory creates an instance of MediaRouteControllerDialogViewModel`() {
-        Robolectric.buildActivity<ComponentActivity>(ComponentActivity::class.java)
+        Robolectric.buildActivity(ComponentActivity::class.java)
             .use { activityController ->
                 val viewModel = ViewModelProvider(
                     owner = activityController.setup().get(),

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
@@ -46,6 +46,15 @@ class TestMediaRouteProvider(context: Context) : MediaRouteProvider(context) {
                     .addControlFilter(intentFilterVideo)
                     .build()
             )
+            .addRoute(
+                MediaRouteDescriptor.Builder(
+                    "presentation_display_route",
+                    "Presentation display route"
+                )
+                    .addControlFilter(intentFilterVideo)
+                    .setPresentationDisplayId(42)
+                    .build()
+            )
             .build()
     }
 }


### PR DESCRIPTION
## Description

This PR extracts all the logic from `MediaRouteControllerDialog` into a dedicated `ViewModel`. This greatly simplifies the Compose code and eases testing of the logic.

## Changes made

- Move logic from `MediaRouteControllerDialog` to `MediaRouteControllerDialogViewModel`.
- Add tests to `MediaRouteControllerDialogViewModel`.
