### PR TITLE
Integrate Dokka and publish documentation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -164,5 +164,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Generate documentation
         run: ./gradlew :dokkaGenerate

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -152,3 +152,17 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Publish to Maven local
         run: ./gradlew publishToMavenLocal
+
+  generate-documentation:
+    name: Generate documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Generate documentation
+        run: ./gradlew :dokkaGenerate

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -166,5 +166,7 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Generate documentation
         run: ./gradlew :dokkaGenerate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,3 @@ jobs:
           branch: gh-pages
           folder: build/dokka/html
           single-commit: true
-          target-folder: api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,12 @@ jobs:
         run: ./gradlew publish
       - name: Create GitHub Release
         run: gh release create ${{ env.VERSION_NAME }} --draft --generate-notes mediarouter-compose/build/outputs/aar/mediarouter-compose-release.aar
+      - name: Generate Dokka documentation
+        run: ./gradlew :dokkaGenerate
+      - name: Deploy Dokka documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build/dokka/html
+          single-commit: true
+          target-folder: api

--- a/README.md
+++ b/README.md
@@ -19,53 +19,8 @@ creating seamless media experiences for your users.
 
 ## Getting started
 
-This library is available as a [GitHub Package][github-packages]. Follow
-GitHub's [documentation][using-github-package] to set up the repository in your project.
-
-### Setting up the repository
-
-```kotlin
-repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/SRGSSR/androidx-mediarouter-compose")
-        credentials {
-            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
-        }
-    }
-}
-```
-
-### Declaring the dependency
-
-In your module `build.gradle(.kts)` file, add the following:
-
-```kotlin
-dependencies {
-    implementation("ch.srgssr.androidx.mediarouter:mediarouter-compose:<version>")
-}
-```
-
-### Display a `MediaRouteButton`
-
-To enable users to connect to remote devices and control media playback, add the `MediaRouteButton`
-to your screen:
-
-```kotlin
-MediaRouteButton()
-```
-
-By default, no routes are displayed because it uses an empty `MediaRouteSelector`. Configure this by
-providing your own `MediaRouteSelector`:
-
-```kotlin
-MediaRouteButton(
-    routeSelector = MediaRouteSelector.Builder()
-        .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
-        .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
-        .build(),
-)
-```
+Please check the [documentation][androidx-mediarouter-compose-doc] to know how to use AndroidX
+MediaRouter Compose in your project.
 
 ## Release
 
@@ -77,8 +32,7 @@ the `x.y.z` pattern is pushed.
 See the [license][license] file for more information.
 
 [androidx-mediarouter]: https://developer.android.com/media/routing/mediarouter
+[androidx-mediarouter-compose-doc]: https://srgssr.github.io/androidx-mediarouter-compose
 [compose]: https://developer.android.com/compose
-[github-packages]: https://github.com/orgs/SRGSSR/packages?repo_name=androidx-mediarouter-compose
 [license]: https://github.com/SRGSSR/androidx-mediarouter-compose/blob/main/LICENSE
 [new-issue]: https://github.com/SRGSSR/androidx-mediarouter-compose/issues/new/choose
-[using-github-package]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -5,6 +10,8 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.dokka.javadoc) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlinx.kover)
@@ -20,8 +27,36 @@ allprojects {
         ignoredBuildTypes = listOf("release")
         parallel = true
     }
+
+    afterEvaluate {
+        if (pluginManager.hasPlugin("org.jetbrains.dokka")) {
+            dokka {
+                moduleName = if (path == ":") "AndroidX MediaRouter Compose" else name
+                moduleVersion = providers.environmentVariable("VERSION_NAME").orElse("main")
+
+                pluginsConfiguration.html {
+                    customStyleSheets.from(layout.settingsDirectory.file("config/dokka/androidx-mediarouter-compose.css"))
+                    footerMessage = "© SRG SSR"
+                }
+
+                dokkaSourceSets.findByName("main")?.apply {
+                    externalDocumentationLinks.register("kotlinx.coroutines") {
+                        url("https://kotlinlang.org/api/kotlinx.coroutines")
+                        packageListUrl("https://kotlinlang.org/api/kotlinx.coroutines/package-list")
+                    }
+
+                    sourceLink {
+                        localDirectory.set(layout.projectDirectory.dir("src"))
+                        remoteUrl("https://github.com/SRGSSR/androidx-mediarouter-compose/tree/${moduleVersion.get()}/${project.name}/src")
+                    }
+                }
+            }
+        }
+    }
 }
 
 dependencies {
+    dokka(project(":mediarouter-compose"))
+
     kover(project(":mediarouter-compose"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ allprojects {
                 }
 
                 dokkaSourceSets.findByName("main")?.apply {
+                    includes.from(layout.settingsDirectory.file("docs/${this@allprojects.name}.md"))
+
                     externalDocumentationLinks.register("kotlinx.coroutines") {
                         url("https://kotlinlang.org/api/kotlinx.coroutines")
                         packageListUrl("https://kotlinlang.org/api/kotlinx.coroutines/package-list")
@@ -52,6 +54,12 @@ allprojects {
                 }
             }
         }
+    }
+}
+
+dokka {
+    dokkaPublications.html {
+        includes.from(layout.settingsDirectory.file("docs/${project.name}.md"))
     }
 }
 

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -5,6 +5,29 @@ output-reports:
     - 'TxtOutputReport'
     - 'XmlOutputReport'
 
+comments:
+  AbsentOrWrongFileLicense:
+    active: true
+
+  DeprecatedBlockTag:
+    active: true
+
+  OutdatedDocumentation:
+    active: true
+
+  UndocumentedPublicClass:
+    active: true
+    excludes: [ '**/demo/**' ]
+    ignoreDefaultCompanionObject: true
+
+  UndocumentedPublicFunction:
+    active: true
+    excludes: [ '**/demo/**' ]
+
+  UndocumentedPublicProperty:
+    active: true
+    excludes: [ '**/demo/**' ]
+
 complexity:
   LongParameterList:
     ignoreAnnotated: [ 'Composable' ]

--- a/config/dokka/androidx-mediarouter-compose.css
+++ b/config/dokka/androidx-mediarouter-compose.css
@@ -1,0 +1,3 @@
+#filter-section, .platform-tags {
+    display: none;
+}

--- a/config/license.template
+++ b/config/license.template
@@ -1,0 +1,4 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application

--- a/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
+++ b/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose.demo
 
 import android.os.Bundle

--- a/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/Theme.kt
+++ b/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/Theme.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose.demo
 
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
 <resources>
     <string name="app_name">AndroidX MediaRouter Compose</string>
 </resources>

--- a/demo/src/main/res/xml/backup_rules.xml
+++ b/demo/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
+<!--
    Sample backup rules file; uncomment and customize as necessary.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.

--- a/demo/src/main/res/xml/data_extraction_rules.xml
+++ b/demo/src/main/res/xml/data_extraction_rules.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
+<!--
    Sample data extraction rules file; uncomment and customize as necessary.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
    for details.

--- a/docs/androidx-mediarouter-compose.md
+++ b/docs/androidx-mediarouter-compose.md
@@ -1,0 +1,41 @@
+## AndroidX MediaRouter Compose
+
+Simplify media routing in your [Compose][compose] app with this native Material
+3 [MediaRouter][androidx-mediarouter] library. Enjoy easy integration, a pure Compose-friendly
+approach, and no need for `AppCompatActivity` or `Theme.AppCompat.*`. Focus on what matters:
+creating seamless media experiences for your users.
+
+### Add the dependency
+
+This library is available as a [GitHub Package][github-package]. Follow
+GitHub's [documentation][using-github-package] to add the repository to your project.
+
+#### Set up the repository
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/SRGSSR/androidx-mediarouter-compose")
+        credentials {
+            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+        }
+        content {
+            includeGroup("ch.srgssr.androidx.mediarouter")
+        }
+    }
+}
+```
+
+#### Declaring the dependency
+
+In your module `build.gradle(.kts)` file, add the following dependency:
+
+```kotlin
+implementation("ch.srgssr.androidx.mediarouter:mediarouter-compose:<version>")
+```
+
+[androidx-mediarouter]: https://developer.android.com/media/routing/mediarouter
+[compose]: https://developer.android.com/compose
+[github-package]: https://github.com/orgs/SRGSSR/packages?repo_name=androidx-mediarouter-compose
+[using-github-package]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package

--- a/docs/mediarouter-compose.md
+++ b/docs/mediarouter-compose.md
@@ -1,23 +1,7 @@
 # Module mediarouter-compose
 
-This module provides Compose components to integrate Media Routing in your application, as well as
-[`ViewModel`][androidx.lifecycle.ViewModel]s to help you build your own experience.
+This module provides Compose components to integrate Media Routing in your application.
 
 # Package ch.srgssr.androidx.mediarouter.compose
 
-This package contains the Compose components and [`ViewModel`][androidx.lifecycle.ViewModel]s to
-integrate Media Routing in your library.
-
-| Feature           | Component                                                                                         | `ViewModel`                                                                                                         |
-|-------------------|---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| Cast icon button  | [`MediaRouteButton`][ch.srgssr.androidx.mediarouter.compose.MediaRouteButton]                     | [`MediaRouteButtonViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteButtonViewModel]                     |
-| Chooser dialog    | [`MediaRouteChooserDialog`][ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialog]       | [`MediaRouteChooserDialogViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel]       |
-| Controller dialog | [`MediaRouteControllerDialog`][ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialog] | [`MediaRouteControllerDialogViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialogViewModel] |
-
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteButton]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-button.html
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteButtonViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-button-view-model/index.html
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialog]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-chooser-dialog.html
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-chooser-dialog-view-model/index.html
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialog]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-controller-dialog.html
-[ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialogViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-controller-dialog-view-model/index.html
-[androidx.lifecycle.ViewModel]: https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModel.html
+This package contains the Compose components to integrate Media Routing in your application.

--- a/docs/mediarouter-compose.md
+++ b/docs/mediarouter-compose.md
@@ -1,0 +1,23 @@
+# Module mediarouter-compose
+
+This module provides Compose components to integrate Media Routing in your application, as well as
+[`ViewModel`][androidx.lifecycle.ViewModel]s to help you build your own experience.
+
+# Package ch.srgssr.androidx.mediarouter.compose
+
+This package contains the Compose components and [`ViewModel`][androidx.lifecycle.ViewModel]s to
+integrate Media Routing in your library.
+
+| Feature           | Component                                                                                         | `ViewModel`                                                                                                         |
+|-------------------|---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| Cast icon button  | [`MediaRouteButton`][ch.srgssr.androidx.mediarouter.compose.MediaRouteButton]                     | [`MediaRouteButtonViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteButtonViewModel]                     |
+| Chooser dialog    | [`MediaRouteChooserDialog`][ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialog]       | [`MediaRouteChooserDialogViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel]       |
+| Controller dialog | [`MediaRouteControllerDialog`][ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialog] | [`MediaRouteControllerDialogViewModel`][ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialogViewModel] |
+
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteButton]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-button.html
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteButtonViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-button-view-model/index.html
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialog]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-chooser-dialog.html
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-chooser-dialog-view-model/index.html
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialog]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-controller-dialog.html
+[ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialogViewModel]: https://srgssr.github.io/androidx-mediarouter-compose/mediarouter-compose/ch.srgssr.androidx.mediarouter.compose/-media-route-controller-dialog-view-model/index.html
+[androidx.lifecycle.ViewModel]: https://developer.android.com/reference/kotlin/androidx/lifecycle/ViewModel.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,10 @@ kotlin.code.style=official
 # Enable Compose Screenshot testing
 # https://developer.android.com/studio/preview/compose-screenshot-testing
 android.experimental.enableScreenshotTest=true
+
+# Use Dokka 2 Gradle Plugin
+# https://kotlinlang.org/docs/dokka-migration.html#migrate-your-project
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+org.jetbrains.dokka.experimental.tryK2=true
+org.jetbrains.dokka.experimental.tryK2.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-test-core = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
 coil = "3.1.0"
 detekt = "1.23.8"
+dokka = "2.0.0"
 junit = "4.13.2"
 kotlin = "2.1.10"
 kotlinx-coroutines = "1.10.1"
@@ -50,6 +51,8 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover" }

--- a/mediarouter-compose/src/main/AndroidManifest.xml
+++ b/mediarouter-compose/src/main/AndroidManifest.xml
@@ -1,2 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
 <manifest />

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionState.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionState.kt
@@ -1,10 +1,31 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import androidx.annotation.StringRes
 import androidx.mediarouter.R
 
+/**
+ * The connection state of a cast route.
+ *
+ * @property contentDescriptionRes The content description associated with the connection state.
+ */
 internal enum class CastConnectionState(@StringRes val contentDescriptionRes: Int) {
+    /**
+     * The device is connected to a Cast session.
+     */
     Connected(R.string.mr_cast_button_connected),
+
+    /**
+     * The device is connecting to a Cast session.
+     */
     Connecting(R.string.mr_cast_button_connecting),
+
+    /**
+     * The device is not connected to a Cast session.
+     */
     Disconnected(R.string.mr_cast_button_disconnected),
 }

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastIcon.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/CastIcon.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import androidx.compose.animation.animateColorAsState

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtils.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtils.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.content.Context

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import androidx.compose.foundation.layout.Arrangement

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.app.Application
@@ -21,16 +26,48 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
+/**
+ * [ViewModel] exposing useful information for building [MediaRouteButton].
+ *
+ * @param application The [Application] instance.
+ * @param savedStateHandle The [SavedStateHandle] instance.
+ * @param routeSelector The media route selector for filtering the routes that the user can select
+ * using the media route chooser dialog.
+ *
+ * @see MediaRouteChooserDialogViewModel.Factory
+ */
 internal class MediaRouteButtonViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle,
     private val routeSelector: MediaRouteSelector,
 ) : ViewModel() {
+    /**
+     * The type of dialog to show.
+     */
     enum class DialogType {
+        /**
+         * Show the chooser dialog to select a route to connect to.
+         */
         Chooser,
+
+        /**
+         * Show the dynamic chooser dialog to select a route to connect to.
+         */
         DynamicChooser,
+
+        /**
+         * Show the controller dialog for the currently selected route.
+         */
         Controller,
+
+        /**
+         * Show the dynamic controller dialog for the currently selected route.
+         */
         DynamicController,
+
+        /**
+         * No dialog should be shown.
+         */
         None,
     }
 
@@ -40,6 +77,9 @@ internal class MediaRouteButtonViewModel(
     private val routerUpdates = MutableStateFlow(0)
     private val showDialog = savedStateHandle.getStateFlow(KEY_SHOW_DIALOG, false)
 
+    /**
+     * The [CastConnectionState] for the currently selected route.
+     */
     val castConnectionState = routerUpdates
         .map { router.selectedRoute }
         .map { route ->
@@ -55,6 +95,10 @@ internal class MediaRouteButtonViewModel(
             }
         }
         .stateIn(viewModelScope, WhileSubscribed(), CastConnectionState.Disconnected)
+
+    /**
+     * The type of dialog to show.
+     */
     val dialogType = combine(showDialog, routerUpdates) { showDialog, _ ->
         if (!showDialog) {
             return@combine DialogType.None
@@ -91,10 +135,16 @@ internal class MediaRouteButtonViewModel(
         }
     }
 
+    /**
+     * Show the dialog.
+     */
     fun showDialog() {
         savedStateHandle[KEY_SHOW_DIALOG] = true
     }
 
+    /**
+     * Hide the dialog.
+     */
     fun hideDialog() {
         savedStateHandle[KEY_SHOW_DIALOG] = false
     }
@@ -109,6 +159,12 @@ internal class MediaRouteButtonViewModel(
         private const val KEY_SHOW_DIALOG = "showDialog"
     }
 
+    /**
+     * Factory for [MediaRouteButtonViewModel].
+     *
+     * @param routeSelector  The media route selector for filtering the routes that the user can
+     * select using the media route chooser dialog.
+     */
     class Factory(private val routeSelector: MediaRouteSelector) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val application = checkNotNull(extras[APPLICATION_KEY])

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.graphics.drawable.Drawable

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import androidx.compose.animation.core.animateFloatAsState

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogViewModel.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.app.Application

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionStateTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/CastConnectionStateTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import androidx.mediarouter.R

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtilsTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtilsTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.content.Context

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.app.Application

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.app.Application

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 package ch.srgssr.androidx.mediarouter.compose
 
 import android.content.Context

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
 pluginManagement {
     repositories {
         google {


### PR DESCRIPTION
## Description

This PR sets up Dokka and publishes the documentation on GitHub Pages. It is now accessible [here](https://srgssr.github.io/androidx-mediarouter-compose/).

## Changes made

- Integrate and configure Dokka.
- Update the publication task to use Dokka-generated artefacts.
- Update Detekt configuration to enforce documentation on public symbols.
- Add missing documentation and license header.
- Move the setup documentation out of the `README.md` file into the GitHub Page.
- Update the `release.yml` workflow to generate and publish the documentation.
- Update the `quality.yml` workflow to generate the documentation.