### PR TITLE
Use the non-dynamic dialog until the corresponding tickets are implemented

### DIFF
--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
@@ -60,14 +60,26 @@ fun MediaRouteButton(
             onDismissRequest = onDismissRequest,
         )
     },
-    mediaRouteDynamicChooserDialog: @Composable () -> Unit = {}, // TODO
+    mediaRouteDynamicChooserDialog: @Composable (onDismissRequest: () -> Unit) -> Unit = { onDismissRequest ->
+        // TODO Implement the correct dialog (see https://github.com/SRGSSR/androidx-mediarouter-compose/issues/18)
+        MediaRouteChooserDialog(
+            routeSelector = routeSelector,
+            onDismissRequest = onDismissRequest,
+        )
+    },
     mediaRouteControllerDialog: @Composable (onDismissRequest: () -> Unit) -> Unit = { onDismissRequest ->
         MediaRouteControllerDialog(
             routeSelector = routeSelector,
             onDismissRequest = onDismissRequest,
         )
     },
-    mediaRouteDynamicControllerDialog: @Composable () -> Unit = {}, // TODO
+    mediaRouteDynamicControllerDialog: @Composable (onDismissRequest: () -> Unit) -> Unit = { onDismissRequest ->
+        // TODO Implement the correct dialog (see https://github.com/SRGSSR/androidx-mediarouter-compose/issues/19)
+        MediaRouteControllerDialog(
+            routeSelector = routeSelector,
+            onDismissRequest = onDismissRequest,
+        )
+    },
 ) {
     val viewModel = viewModel<MediaRouteButtonViewModel>(
         key = routeSelector.toString(),
@@ -85,9 +97,9 @@ fun MediaRouteButton(
 
     when (dialogType) {
         DialogType.Chooser -> mediaRouteChooserDialog(viewModel::hideDialog)
-        DialogType.DynamicChooser -> mediaRouteDynamicChooserDialog()
+        DialogType.DynamicChooser -> mediaRouteDynamicChooserDialog(viewModel::hideDialog)
         DialogType.Controller -> mediaRouteControllerDialog(viewModel::hideDialog)
-        DialogType.DynamicController -> mediaRouteDynamicControllerDialog()
+        DialogType.DynamicController -> mediaRouteDynamicControllerDialog(viewModel::hideDialog)
         DialogType.None -> Unit
     }
 }


### PR DESCRIPTION
## Description

This PR uses the non-dynamic already implemented dialogs instead of the no-op TODOs.

This is a simple workaround until #18 and #19 are implemented.

## Changes made

- Use `MediaRouteChooserDialog` instead of the corresponding dynamic dialog.
- Use `MediaRouteControllerDialog` instead of the corresponding dynamic dialog.