### PR TITLE
Update the `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,4 @@ jobs:
       - name: Publish to GitHub Packages
         run: ./gradlew publish
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          generate_release_notes: true
-          fail_on_unmatched_files: true
-          files: mediarouter-compose/build/outputs/aar/mediarouter-compose-release.aar
+        run: gh release create ${{ env.VERSION_NAME }} --draft --generate-notes mediarouter-compose/build/outputs/aar/mediarouter-compose-release.aar


### PR DESCRIPTION
## Description

This commit updates the `release.yml` workflow to use the [`gh`](https://cli.github.com/) command line tool to create a new release, instead of a third party action.

## Changes made

- Replace the `softprops/action-gh-release` action with the `gh release create` command.