### PR TITLE
Expose the AndroidX MediaRouter dependency

### DIFF
--- a/mediarouter-compose/build.gradle.kts
+++ b/mediarouter-compose/build.gradle.kts
@@ -104,7 +104,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.mediarouter)
+    api(libs.androidx.mediarouter)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
     implementation(platform(libs.kotlin.bom))


### PR DESCRIPTION
## Description

This commit makes the AndroidX MediaRouter (`androidx.mediarouter:mediarouter`) dependency visible to consumers of this library.

## Changes made

- Change the dependency type from `implementation` to `api`.