### PR TITLE
Give workflow read permissions only by default

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,6 +18,8 @@ jobs:
   android-lint:
     name: Android Lint
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,6 +44,8 @@ jobs:
   detekt:
     name: Detekt
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   android-lint:
     name: Android Lint
@@ -63,6 +66,8 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,7 +67,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Make the `quality.yml` workflow use read permission by default.

Fixes https://github.com/SRGSSR/androidx-mediarouter-compose/security/code-scanning/37, https://github.com/SRGSSR/androidx-mediarouter-compose/security/code-scanning/36, https://github.com/SRGSSR/androidx-mediarouter-compose/security/code-scanning/5, https://github.com/SRGSSR/androidx-mediarouter-compose/security/code-scanning/4, https://github.com/SRGSSR/androidx-mediarouter-compose/security/code-scanning/3.

## Changes made

- Make the jobs in `quality.yml` workflow read-only by default.
- Add `pull-requests: write` to the `unit-test` job.