### PR TITLE
Update the demo app to include a video player

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,12 @@ dependencyAnalysis {
                 severity("fail")
             }
         }
+
+        project(":demo") {
+            onUnusedDependencies {
+                exclude(libs.androidx.media3.exoplayer.dash)
+            }
+        }
     }
 }
 

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -47,4 +47,4 @@ style:
     ignoreAnnotated: [ 'Composable' ]
 
   UnusedPrivateMember:
-    ignoreAnnotated: [ 'Preview' ]
+    ignoreAnnotated: [ 'Preview', 'PreviewLightDark' ]

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         applicationId = "ch.srgssr.androidx.mediarouter.compose.demo"
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }
@@ -47,6 +47,7 @@ android {
         checkAllWarnings = true
         checkDependencies = true
         sarifReport = true
+        warningsAsErrors = true
     }
 }
 
@@ -54,6 +55,7 @@ dependencies {
     implementation(project(":mediarouter-compose"))
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.annotation.experimental)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.foundation.layout)
@@ -62,10 +64,20 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.text)
     implementation(libs.androidx.compose.ui.tooling.preview)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.unit)
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.fragment)
+    implementation(libs.androidx.lifecycle.viewmodel)
+    implementation(libs.androidx.media3.cast)
+    implementation(libs.androidx.media3.common)
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.exoplayer.dash)
+    implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.mediarouter)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.play.services.cast.framework)
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -13,6 +15,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="androidx.media3.cast.DefaultCastOptionsProvider" />
 
         <activity
             android:name=".MainActivity"

--- a/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
+++ b/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
@@ -8,32 +8,44 @@ package ch.srgssr.androidx.mediarouter.compose.demo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cast
+import androidx.compose.material.icons.filled.SwitchLeft
+import androidx.compose.material.icons.filled.SwitchRight
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
 import androidx.mediarouter.app.MediaRouteButton
 import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteSelector
 import ch.srgssr.androidx.mediarouter.compose.MediaRouteButton
 
 class MainActivity : FragmentActivity() {
+    private val mainViewModel by viewModels<MainViewModel>()
     private val routeSelector = MediaRouteSelector.Builder()
         .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
         .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
@@ -45,74 +57,157 @@ class MainActivity : FragmentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            DemoTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Row(
-                        modifier = Modifier
-                            .padding(innerPadding)
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceEvenly,
-                    ) {
-                        MediaRouteButtonType(
-                            label = "Compose",
-                            content = {
-                                MediaRouteButton(routeSelector = routeSelector)
-                            },
-                        )
+            val player by mainViewModel.player.collectAsState()
 
-                        MediaRouteButtonType(
-                            label = "AppCompat",
-                            content = {
-                                AndroidView(
-                                    factory = { context ->
-                                        MediaRouteButton(context).apply {
-                                            routeSelector = this@MainActivity.routeSelector
-                                        }
-                                    },
-                                )
-                            },
-                        )
-                    }
-                }
+            var useCompose by remember { mutableStateOf(true) }
+
+            DemoTheme {
+                MainView(
+                    player = player,
+                    useCompose = useCompose,
+                    routeSelector = routeSelector,
+                    modifier = Modifier.fillMaxSize(),
+                    onFabClick = { useCompose = !useCompose },
+                )
             }
         }
     }
 }
 
 @Composable
-private fun MediaRouteButtonType(
-    label: String,
+internal fun MainView(
+    player: Player,
+    useCompose: Boolean,
+    routeSelector: MediaRouteSelector,
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    onFabClick: () -> Unit,
 ) {
-    Column(
+    Scaffold(
         modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.titleLarge,
-        )
+        floatingActionButton = {
+            SwitchImplementationButton(
+                useCompose = useCompose,
+                onClick = onFabClick,
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Player(
+                player = player,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(fraction = 0.5f)
+                    .align(Alignment.CenterStart),
+            )
 
-        content()
+            CastIcon(
+                useCompose = useCompose,
+                routeSelector = routeSelector,
+                modifier = Modifier
+                    .padding(all = 16.dp)
+                    .align(Alignment.TopEnd),
+            )
+        }
     }
 }
 
-@Preview
 @Composable
-private fun MediaRouteButtonTypePreview() {
-    DemoTheme {
-        MediaRouteButtonType(
-            label = "Type",
-            content = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        imageVector = Icons.Default.Cast,
-                        contentDescription = null,
-                    )
+private fun SwitchImplementationButton(
+    useCompose: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    ExtendedFloatingActionButton(
+        text = {
+            val textResId = if (useCompose) R.string.use_androidx else R.string.use_compose
+
+            Text(text = stringResource(textResId))
+        },
+        icon = {
+            val icon = if (useCompose) Icons.Default.SwitchLeft else Icons.Default.SwitchRight
+
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+            )
+        },
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun CastIcon(
+    useCompose: Boolean,
+    routeSelector: MediaRouteSelector,
+    modifier: Modifier = Modifier,
+) {
+    if (useCompose) {
+        MediaRouteButton(
+            modifier = modifier,
+            routeSelector = routeSelector,
+        )
+    } else {
+        AndroidView(
+            factory = { context ->
+                MediaRouteButton(context).apply {
+                    this.routeSelector = routeSelector
                 }
             },
+            modifier = modifier,
         )
+    }
+}
+
+@Composable
+private fun Player(
+    player: Player,
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        factory = { context ->
+            PlayerView(context).apply {
+                this.player = player
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+@PreviewLightDark
+private fun MainViewAndroidXPreview() {
+    DemoTheme {
+        Surface {
+            val context = LocalContext.current
+
+            MainView(
+                player = ExoPlayer.Builder(context).build(),
+                useCompose = false,
+                routeSelector = MediaRouteSelector.EMPTY,
+                onFabClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun MainViewComposePreview() {
+    DemoTheme {
+        Surface {
+            val context = LocalContext.current
+
+            MainView(
+                player = ExoPlayer.Builder(context).build(),
+                useCompose = true,
+                routeSelector = MediaRouteSelector.EMPTY,
+                onFabClick = {},
+            )
+        }
     }
 }

--- a/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
+++ b/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainActivity.kt
@@ -174,6 +174,9 @@ private fun Player(
                 this.player = player
             }
         },
+        update = { playerView ->
+            playerView.player = player
+        },
         modifier = modifier,
     )
 }

--- a/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainViewModel.kt
+++ b/demo/src/main/java/ch/srgssr/androidx/mediarouter/compose/demo/MainViewModel.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
+package ch.srgssr.androidx.mediarouter.compose.demo
+
+import android.app.Application
+import androidx.annotation.OptIn
+import androidx.core.net.toUri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.cast.CastPlayer
+import androidx.media3.cast.SessionAvailabilityListener
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import com.google.android.gms.cast.framework.CastContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(UnstableApi::class)
+class MainViewModel(application: Application) : AndroidViewModel(application) {
+    private val localPlayer = ExoPlayer.Builder(application).build()
+    private val castPlayer = CastPlayer(CastContext.getSharedInstance(application))
+    private val currentPlayer =
+        MutableStateFlow(if (castPlayer.isCastSessionAvailable) castPlayer else localPlayer)
+
+    val player = currentPlayer
+        .onEach { player ->
+            val oldPlayer = if (player == localPlayer) castPlayer else localPlayer
+            player.volume = oldPlayer.volume
+            player.repeatMode = oldPlayer.repeatMode
+            player.playWhenReady = oldPlayer.playWhenReady
+
+            oldPlayer.currentMediaItem?.let {
+                player.setMediaItem(it, oldPlayer.currentPosition)
+            }
+            oldPlayer.stop()
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = WhileSubscribed(5.seconds.inWholeMilliseconds),
+            initialValue = currentPlayer.value,
+        )
+
+    init {
+        localPlayer.setMediaItem(mediaItem)
+        localPlayer.volume = 0f
+        localPlayer.prepare()
+        localPlayer.play()
+
+        castPlayer.setSessionAvailabilityListener(object : SessionAvailabilityListener {
+            override fun onCastSessionAvailable() {
+                currentPlayer.update { castPlayer }
+            }
+
+            override fun onCastSessionUnavailable() {
+                currentPlayer.update { localPlayer }
+            }
+        })
+    }
+
+    override fun onCleared() {
+        localPlayer.release()
+        castPlayer.setSessionAvailabilityListener(null)
+        castPlayer.release()
+    }
+
+    private companion object {
+        @Suppress("MaxLineLength")
+        private val mediaItem = MediaItem.Builder()
+            .setUri("https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd")
+            .setMimeType(MimeTypes.APPLICATION_MPD)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("Tears of Steel (DASH, adaptive, HD, MP4, H264/aac)")
+                    .setArtworkUri("https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg".toUri())
+                    .build()
+            )
+            .build()
+    }
+}

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
   -->
 <resources>
     <string name="app_name">AndroidX MediaRouter Compose</string>
+    <string name="use_androidx">Use AndroidX</string>
+    <string name="use_compose">Use Compose</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,13 @@ android-compose-screenshot = "0.0.1-alpha09"
 android-gradle-plugin = "8.9.1"
 androidx-activity = "1.10.1"
 androidx-annotation = "1.9.1"
+androidx-annotation-experimental = "1.4.1"
 androidx-compose = "2025.03.01"
 androidx-core = "1.15.0"
 androidx-fragment = "1.8.6"
 androidx-lifecycle = "2.8.7"
 androidx-media = "1.7.0"
+androidx-media3 = "1.6.0"
 androidx-mediarouter = "1.7.0"
 androidx-test-core = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
@@ -20,6 +22,7 @@ junit = "4.13.2"
 kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.1"
 kotlinx-kover = "0.9.1"
+play-services-cast-framework = "22.0.0"
 robolectric = "4.14.1"
 turbine = "1.2.0"
 
@@ -27,6 +30,7 @@ turbine = "1.2.0"
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidx-annotation" }
+androidx-annotation-experimental = { group = "androidx.annotation", name = "annotation-experimental", version.ref = "androidx-annotation-experimental" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose" }
@@ -50,6 +54,11 @@ androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel-savedstate = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-media = { group = "androidx.media", name = "media", version.ref = "androidx-media" }
+androidx-media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "androidx-media3" }
+androidx-media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "androidx-media3" }
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "androidx-media3" }
+androidx-media3-exoplayer-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "androidx-media3" }
+androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "androidx-media3" }
 androidx-mediarouter = { group = "androidx.mediarouter", name = "mediarouter", version.ref = "androidx-mediarouter" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
@@ -61,6 +70,7 @@ kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref 
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+play-services-cast-framework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "play-services-cast-framework" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 robolectric-annotations = { group = "org.robolectric", name = "annotations", version.ref = "robolectric" }
 robolectric-shadows-framework = { group = "org.robolectric", name = "shadows-framework", version.ref = "robolectric" }


### PR DESCRIPTION
## Description

This PR updates the demo application to include a video player.

## Changes made

- Integrate a video player in the demo app. The played video is [Tears of Steel](https://studio.blender.org/projects/tears-of-steel/).
- Add a floating action button to the demo app to switch between the Compose and AppCompat `MediaRouteButton`.
- Add a `MainViewModel` that exposes the `Player` to use, which is either an `ExoPlayer` or a `CastPlayer`.
- Make Android Lint warnings fail the build.
- Update the target SDK version to 36.