### PR TITLE
Add GitHub Workflow to submit dependency graph

### DIFF
--- a/.github/workflows/dependency_graph.yml
+++ b/.github/workflows/dependency_graph.yml
@@ -1,0 +1,30 @@
+name: Submit Dependency Graph
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  submit-dependency-graph:
+    name: Submit Dependency Graph
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version-file: .github/workflows/.java-version
+          distribution: 'temurin'
+      - name: Submit Dependency Graph
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
## Description

This PR adds a new GitHub Workflow to submit the Dependency Graph to GitHub on every push on `main`.
The dependencies will be visible [here](https://github.com/SRGSSR/androidx-mediarouter-compose/network/dependencies).

## Changes made

- Add a new GitHub Workflow to submit Dependency Graph.