### PR TITLE
Fix volume management for device group

### DIFF
--- a/mediarouter-compose/src/screenshotTest/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogScreenshot.kt
+++ b/mediarouter-compose/src/screenshotTest/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogScreenshot.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.core.graphics.createBitmap
+import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.media.ScreenshotMediaRouter
+import ch.srgssr.androidx.mediarouter.compose.MediaRouteControllerDialogViewModel.RouteDetail
 import coil3.Image
 import coil3.annotation.ExperimentalCoilApi
 import coil3.asImage
@@ -34,8 +36,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -43,6 +44,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = false,
                 showVolumeControl = false,
+                groupRouteDetails = emptyList(),
                 customControlView = null,
                 toggleDeviceGroup = {},
                 onKeyEvent = { false },
@@ -51,6 +53,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -62,8 +65,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -71,6 +73,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = true,
                 showVolumeControl = false,
+                groupRouteDetails = emptyList(),
                 customControlView = null,
                 toggleDeviceGroup = {},
                 onKeyEvent = { false },
@@ -79,6 +82,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -90,8 +94,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -99,6 +102,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = false,
                 showVolumeControl = true,
+                groupRouteDetails = emptyList(),
                 customControlView = null,
                 toggleDeviceGroup = {},
                 onKeyEvent = { false },
@@ -107,6 +111,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -118,8 +123,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -127,6 +131,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = true,
                 showVolumeControl = false,
+                groupRouteDetails = emptyList(),
                 customControlView = {
                     Text(text = "Custom control view")
                 },
@@ -137,6 +142,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -148,8 +154,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -157,6 +162,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = true,
                 showVolumeControl = true,
+                groupRouteDetails = emptyList(),
                 customControlView = null,
                 toggleDeviceGroup = {},
                 onKeyEvent = { false },
@@ -165,6 +171,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -176,8 +183,7 @@ class MediaRouteControllerDialogScreenshot {
 
         ScreenshotTheme {
             ControllerDialog(
-                route = router.routes[0],
-                volumeControlEnabled = false,
+                routeDetail = routeDetail(router.routes[0]),
                 imageModel = null,
                 title = "Media title",
                 subtitle = "Media subtitle",
@@ -185,6 +191,7 @@ class MediaRouteControllerDialogScreenshot {
                 isDeviceGroupExpanded = false,
                 showPlaybackControl = true,
                 showVolumeControl = true,
+                groupRouteDetails = emptyList(),
                 customControlView = {
                     Text(text = "Custom control view")
                 },
@@ -195,6 +202,7 @@ class MediaRouteControllerDialogScreenshot {
                 onStopCasting = {},
                 onDisconnect = {},
                 onDismissRequest = {},
+                onVolumeChange = { _, _ -> },
             )
         }
     }
@@ -213,8 +221,7 @@ class MediaRouteControllerDialogScreenshot {
 
             CompositionLocalProvider(LocalAsyncImagePreviewHandler provides imagePreviewHandler) {
                 ControllerDialog(
-                    route = router.routes[0],
-                    volumeControlEnabled = false,
+                    routeDetail = routeDetail(router.routes[0]),
                     imageModel = "https://image.url/",
                     title = "Media title",
                     subtitle = "Media subtitle",
@@ -222,6 +229,7 @@ class MediaRouteControllerDialogScreenshot {
                     isDeviceGroupExpanded = false,
                     showPlaybackControl = true,
                     showVolumeControl = true,
+                    groupRouteDetails = emptyList(),
                     customControlView = null,
                     toggleDeviceGroup = {},
                     onKeyEvent = { false },
@@ -230,6 +238,7 @@ class MediaRouteControllerDialogScreenshot {
                     onStopCasting = {},
                     onDisconnect = {},
                     onDismissRequest = {},
+                    onVolumeChange = { _, _ -> },
                 )
             }
         }
@@ -249,8 +258,7 @@ class MediaRouteControllerDialogScreenshot {
 
             CompositionLocalProvider(LocalAsyncImagePreviewHandler provides imagePreviewHandler) {
                 ControllerDialog(
-                    route = router.routes[0],
-                    volumeControlEnabled = false,
+                    routeDetail = routeDetail(router.routes[0]),
                     imageModel = "https://image.url/",
                     title = "Media title",
                     subtitle = "Media subtitle",
@@ -258,6 +266,7 @@ class MediaRouteControllerDialogScreenshot {
                     isDeviceGroupExpanded = false,
                     showPlaybackControl = true,
                     showVolumeControl = true,
+                    groupRouteDetails = emptyList(),
                     customControlView = null,
                     toggleDeviceGroup = {},
                     onKeyEvent = { false },
@@ -266,6 +275,7 @@ class MediaRouteControllerDialogScreenshot {
                     onStopCasting = {},
                     onDisconnect = {},
                     onDismissRequest = {},
+                    onVolumeChange = { _, _ -> },
                 )
             }
         }
@@ -280,13 +290,16 @@ class MediaRouteControllerDialogScreenshot {
         ScreenshotTheme {
             val imageColor = MaterialTheme.colorScheme.onSurface
             val imagePreviewHandler = AsyncImagePreviewHandler {
-                createImage(imageColor.toArgb(), width = IMAGE_SIZE, height = IMAGE_SIZE * 4 / 3)
+                createImage(
+                    imageColor.toArgb(),
+                    width = IMAGE_SIZE,
+                    height = IMAGE_SIZE * 4 / 3
+                )
             }
 
             CompositionLocalProvider(LocalAsyncImagePreviewHandler provides imagePreviewHandler) {
                 ControllerDialog(
-                    route = router.routes[0],
-                    volumeControlEnabled = false,
+                    routeDetail = routeDetail(router.routes[0]),
                     imageModel = "https://image.url/",
                     title = "Media title",
                     subtitle = "Media subtitle",
@@ -294,6 +307,7 @@ class MediaRouteControllerDialogScreenshot {
                     isDeviceGroupExpanded = false,
                     showPlaybackControl = true,
                     showVolumeControl = true,
+                    groupRouteDetails = emptyList(),
                     customControlView = null,
                     toggleDeviceGroup = {},
                     onKeyEvent = { false },
@@ -302,6 +316,7 @@ class MediaRouteControllerDialogScreenshot {
                     onStopCasting = {},
                     onDisconnect = {},
                     onDismissRequest = {},
+                    onVolumeChange = { _, _ -> },
                 )
             }
         }
@@ -325,6 +340,14 @@ class MediaRouteControllerDialogScreenshot {
         }
 
         return bitmap.asImage()
+    }
+
+    private fun routeDetail(route: MediaRouter.RouteInfo): RouteDetail {
+        return RouteDetail(
+            route = route,
+            volume = route.volume.toFloat(),
+            volumeRange = 0f..route.volumeMax.toFloat(),
+        )
     }
 
     private companion object {

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonTest.kt
@@ -18,6 +18,8 @@ import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.testing.MediaRouterTestHelper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_CONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.findRouteById
 import org.junit.runner.RunWith
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -70,7 +72,7 @@ class MediaRouteButtonTest {
         assertMediaRouteButtonState(
             expectedDialogTypes = listOf(DialogType.None, DialogType.Controller),
             action = {
-                router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+                router.findRouteById(ROUTE_ID_CONNECTED).select()
 
                 onNodeWithTag(TEST_TAG).performClick()
             },
@@ -98,13 +100,6 @@ class MediaRouteButtonTest {
         }
 
         assertEquals(expectedDialogTypes, dialogTypes)
-    }
-
-    private fun MediaRouter.selectRouteById(id: String) {
-        val providerFQCN = TestMediaRouteProvider::class.qualifiedName
-        val fullId = "${context.packageName}/$providerFQCN:$id"
-
-        routes.single { it.id == fullId }.select()
     }
 
     private companion object {

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModelTest.kt
@@ -25,6 +25,11 @@ import androidx.mediarouter.testing.MediaRouterTestHelper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_CONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_CONNECTING
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_DISCONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_INVALID
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.findRouteById
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -90,7 +95,7 @@ class MediaRouteButtonViewModelTest {
 
     @Test
     fun `check the cast connection state with a connected route`() = runTest {
-        router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+        router.findRouteById(ROUTE_ID_CONNECTED).select()
 
         viewModel.castConnectionState.test {
             assertEquals(CastConnectionState.Connected, awaitItem())
@@ -99,7 +104,7 @@ class MediaRouteButtonViewModelTest {
 
     @Test
     fun `check the cast connection state with a connecting route`() = runTest {
-        router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTING)
+        router.findRouteById(ROUTE_ID_CONNECTING).select()
 
         viewModel.castConnectionState.test {
             assertEquals(CastConnectionState.Connecting, awaitItem())
@@ -108,7 +113,7 @@ class MediaRouteButtonViewModelTest {
 
     @Test
     fun `check the cast connection state with a disconnected route`() = runTest {
-        router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_DISCONNECTED)
+        router.findRouteById(ROUTE_ID_DISCONNECTED).select()
 
         viewModel.castConnectionState.test {
             assertEquals(CastConnectionState.Disconnected, awaitItem())
@@ -117,7 +122,7 @@ class MediaRouteButtonViewModelTest {
 
     @Test(expected = IllegalStateException::class)
     fun `check the cast connection state with an invalid state route`() = runTest {
-        router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_INVALID)
+        router.findRouteById(ROUTE_ID_INVALID).select()
 
         viewModel.castConnectionState.test {
             assertEquals(CastConnectionState.Disconnected, awaitItem())
@@ -174,7 +179,7 @@ class MediaRouteButtonViewModelTest {
     @Test
     fun `check the dialog type when the dialog is hidden with a non-default route`() = runTest {
         viewModel.dialogType.test {
-            router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+            router.findRouteById(ROUTE_ID_CONNECTED).select()
             viewModel.hideDialog()
 
             assertEquals(DialogType.None, awaitItem())
@@ -184,7 +189,7 @@ class MediaRouteButtonViewModelTest {
     @Test
     fun `check the dialog type when the dialog is shown with a non-default route`() = runTest {
         viewModel.dialogType.test {
-            router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+            router.findRouteById(ROUTE_ID_CONNECTED).select()
             viewModel.showDialog()
 
             assertEquals(DialogType.None, awaitItem())
@@ -198,7 +203,7 @@ class MediaRouteButtonViewModelTest {
             router.routerParams = MediaRouterParams.Builder().build()
 
             viewModel.dialogType.test {
-                router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+                router.findRouteById(ROUTE_ID_CONNECTED).select()
                 viewModel.showDialog()
 
                 assertEquals(DialogType.None, awaitItem())
@@ -214,7 +219,7 @@ class MediaRouteButtonViewModelTest {
                 .build()
 
             viewModel.dialogType.test {
-                router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+                router.findRouteById(ROUTE_ID_CONNECTED).select()
                 viewModel.showDialog()
 
                 assertEquals(DialogType.None, awaitItem())
@@ -258,12 +263,5 @@ class MediaRouteButtonViewModelTest {
 
                 assertIs<MediaRouteButtonViewModel>(viewModel)
             }
-    }
-
-    private fun MediaRouter.selectRouteById(id: String) {
-        val providerFQCN = TestMediaRouteProvider::class.qualifiedName
-        val fullId = "${context.packageName}/$providerFQCN:$id"
-
-        routes.single { it.id == fullId }.select()
     }
 }

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogViewModelTest.kt
@@ -27,6 +27,12 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel.ChooserState
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_ID_CONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_NAME_CONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_NAME_DISCONNECTED
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_NAME_GROUP
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.ROUTE_NAME_PRESENTATION
+import ch.srgssr.androidx.mediarouter.compose.TestMediaRouteProvider.Companion.findRouteById
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -124,9 +130,10 @@ class MediaRouteChooserDialogViewModelTest {
         viewModel.routes.test {
             assertEquals(
                 expected = listOf(
-                    TestMediaRouteProvider.ROUTE_NAME_CONNECTED,
-                    TestMediaRouteProvider.ROUTE_NAME_DISCONNECTED,
-                    TestMediaRouteProvider.ROUTE_NAME_PRESENTATION,
+                    ROUTE_NAME_CONNECTED,
+                    ROUTE_NAME_DISCONNECTED,
+                    ROUTE_NAME_GROUP,
+                    ROUTE_NAME_PRESENTATION,
                 ),
                 actual = awaitItem().map { it.name },
             )
@@ -198,7 +205,7 @@ class MediaRouteChooserDialogViewModelTest {
             viewModel.showDialog.test {
                 assertTrue(awaitItem())
 
-                router.selectRouteById(TestMediaRouteProvider.ROUTE_ID_CONNECTED)
+                router.findRouteById(ROUTE_ID_CONNECTED).select()
 
                 shadowOf(Looper.getMainLooper()).idle()
 
@@ -239,12 +246,5 @@ class MediaRouteChooserDialogViewModelTest {
 
                 assertIs<MediaRouteChooserDialogViewModel>(viewModel)
             }
-    }
-
-    private fun MediaRouter.selectRouteById(id: String) {
-        val providerFQCN = TestMediaRouteProvider::class.qualifiedName
-        val fullId = "${context.packageName}/$providerFQCN:$id"
-
-        routes.single { it.id == fullId }.select()
     }
 }

--- a/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
+++ b/mediarouter-compose/src/test/java/ch/srgssr/androidx/mediarouter/compose/TestMediaRouteProvider.kt
@@ -11,7 +11,9 @@ import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteDescriptor
 import androidx.mediarouter.media.MediaRouteProvider
 import androidx.mediarouter.media.MediaRouteProviderDescriptor
+import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.media.MediaRouter.RouteInfo
+import androidx.test.core.app.ApplicationProvider
 
 internal class TestMediaRouteProvider(context: Context) : MediaRouteProvider(context) {
     init {
@@ -25,18 +27,27 @@ internal class TestMediaRouteProvider(context: Context) : MediaRouteProvider(con
                 MediaRouteDescriptor.Builder(ROUTE_ID_DISCONNECTED, ROUTE_NAME_DISCONNECTED)
                     .setConnectionState(RouteInfo.CONNECTION_STATE_DISCONNECTED)
                     .addControlFilter(intentFilterVideo)
+                    .setVolume(25)
+                    .setVolumeMax(100)
+                    .setVolumeHandling(RouteInfo.PLAYBACK_VOLUME_VARIABLE)
                     .build()
             )
             .addRoute(
                 MediaRouteDescriptor.Builder(ROUTE_ID_CONNECTING, ROUTE_NAME_CONNECTING)
                     .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTING)
                     .addControlFilter(intentFilterAudio)
+                    .setVolume(50)
+                    .setVolumeMax(100)
+                    .setVolumeHandling(RouteInfo.PLAYBACK_VOLUME_VARIABLE)
                     .build()
             )
             .addRoute(
                 MediaRouteDescriptor.Builder(ROUTE_ID_CONNECTED, ROUTE_NAME_CONNECTED)
                     .setConnectionState(RouteInfo.CONNECTION_STATE_CONNECTED)
                     .addControlFilter(intentFilterVideo)
+                    .setVolume(75)
+                    .setVolumeMax(100)
+                    .setVolumeHandling(RouteInfo.PLAYBACK_VOLUME_VARIABLE)
                     .build()
             )
             .addRoute(
@@ -57,7 +68,34 @@ internal class TestMediaRouteProvider(context: Context) : MediaRouteProvider(con
                     .setPresentationDisplayId(42)
                     .build()
             )
+            .addRoute(
+                MediaRouteDescriptor.Builder(ROUTE_ID_GROUP, ROUTE_NAME_GROUP)
+                    .addControlFilter(intentFilterVideo)
+                    .setVolume(50)
+                    .setVolumeMax(100)
+                    .setVolumeHandling(RouteInfo.PLAYBACK_VOLUME_VARIABLE)
+                    .addGroupMemberId(ROUTE_ID_DISCONNECTED)
+                    .addGroupMemberId(ROUTE_ID_CONNECTING)
+                    .addGroupMemberId(ROUTE_ID_CONNECTED)
+                    .build()
+            )
             .build()
+    }
+
+    override fun onCreateRouteController(routeId: String, routeGroupId: String): RouteController? {
+        val route = MediaRouter.getInstance(context).findRouteById(routeId)
+
+        return TestRouteController(route)
+    }
+
+    private class TestRouteController(private val route: RouteInfo) : RouteController() {
+        override fun onSetVolume(volume: Int) {
+            route.requestSetVolume(volume)
+        }
+
+        override fun onUpdateVolume(delta: Int) {
+            route.requestUpdateVolume(delta)
+        }
     }
 
     companion object {
@@ -66,6 +104,7 @@ internal class TestMediaRouteProvider(context: Context) : MediaRouteProvider(con
         const val ROUTE_ID_CONNECTING = "connecting_route"
         const val ROUTE_ID_DISABLED = "disabled_route"
         const val ROUTE_ID_DISCONNECTED = "disconnected_route"
+        const val ROUTE_ID_GROUP = "group_route"
         const val ROUTE_ID_INVALID = "invalid_state_route"
         const val ROUTE_ID_PRESENTATION = "presentation_display_route"
 
@@ -75,7 +114,16 @@ internal class TestMediaRouteProvider(context: Context) : MediaRouteProvider(con
         const val ROUTE_NAME_CONNECTING = "Connecting route"
         const val ROUTE_NAME_DISABLED = "Disabled route"
         const val ROUTE_NAME_DISCONNECTED = "Disconnected route"
+        const val ROUTE_NAME_GROUP = "Group route"
         const val ROUTE_NAME_INVALID = "Invalid state route"
         const val ROUTE_NAME_PRESENTATION = "Presentation display route"
+
+        fun MediaRouter.findRouteById(routeId: String): RouteInfo {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            val providerFQCN = TestMediaRouteProvider::class.qualifiedName
+            val fullId = "${context.packageName}/$providerFQCN:$routeId"
+
+            return routes.single { it.id == fullId }
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR updates the volume management for device groups. When casting on a group:
- If the user changes the volume of the group, the volume changes and the member routes are updated accordingly.
- If the user changes the volume of one of the member routes, the UI updates, but the volume of the route does not change (similarly to what is done in the main MediaRouter implementation).

## Changes made

- Keep a list of volumes for each route, which is updated based on user interaction and callback from the `MediaRouter`.
- Send volume change requests at most once every 500 ms.
- Add a new helper function in tests to access a specific route.
- Add a new route to the test route provider to emulate a group of devices.