### PR TITLE
Enable explicit API mode and add Binary Compatibility Validator

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -212,3 +212,47 @@ jobs:
         run: |
           echo "::error ::Dependency Analysis failed."
           exit 1
+
+  binary-compatibility-validator:
+    name: Binary Compatibility Validator
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.WORKFLOW_PAT }}
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version-file: .github/workflows/.java-version
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+      - name: Run API check
+        id: api_check
+        continue-on-error: true
+        run: ./gradlew apiCheck
+      - name: Update API dumps
+        id: update_api_dumps
+        if: env.WORKFLOW_PAT != '' && steps.api_check.outcome == 'failure' && github.event_name == 'pull_request'
+        run: ./gradlew apiDump
+      - name: Push new API dumps
+        if: steps.update_api_dumps.outcome == 'success'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: '*/*.api'
+          disable_globbing: true
+          commit_message: "Update API dumps"
+      # If the WORKFLOW_PAT secret is not available (ie. from forks), the push above won't trigger a CI build.
+      # So instead, we ask the contributor to manually update and push the new API dumps.
+      - name: Request API dumps to be updated
+        if: env.WORKFLOW_PAT == '' && steps.api_check.outcome == 'failure' && github.event_name == 'pull_request'
+        run: |
+          echo "::error ::API dumps are outdated. Run './gradlew apiDump' to update them and push the changes."
+          exit 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.dokka.javadoc) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlinx.binary.compatibility.validator)
     alias(libs.plugins.kotlinx.kover)
 }
 
@@ -60,6 +61,14 @@ allprojects {
 
 subprojects {
     pluginManager.apply("com.autonomousapps.dependency-analysis")
+}
+
+apiValidation {
+    ignoredProjects.add("demo")
+    // See https://github.com/Kotlin/binary-compatibility-validator/issues/74
+    ignoredClasses.add("ch.srgssr.androidx.mediarouter.compose.ComposableSingletons\$CastIconKt")
+    ignoredClasses.add("ch.srgssr.androidx.mediarouter.compose.ComposableSingletons\$MediaRouteChooserDialogKt")
+    ignoredClasses.add("ch.srgssr.androidx.mediarouter.compose.ComposableSingletons\$MediaRouteControllerDialogKt")
 }
 
 dokka {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ detekt = "1.23.8"
 dokka = "2.0.0"
 junit = "4.13.2"
 kotlin = "2.1.21"
+kotlinx-binary-compatibility-validator = "0.17.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-kover = "0.9.1"
 play-services-cast-framework = "22.0.0"
@@ -89,5 +90,6 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility-validator" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover" }
 maven-publish = { id = "org.gradle.maven-publish" }

--- a/mediarouter-compose/api/mediarouter-compose.api
+++ b/mediarouter-compose/api/mediarouter-compose.api
@@ -1,0 +1,23 @@
+public final class ch/srgssr/androidx/mediarouter/compose/DialogType : java/lang/Enum {
+	public static final field Chooser Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static final field Controller Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static final field DynamicChooser Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static final field DynamicController Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static final field None Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lch/srgssr/androidx/mediarouter/compose/DialogType;
+	public static fun values ()[Lch/srgssr/androidx/mediarouter/compose/DialogType;
+}
+
+public final class ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonKt {
+	public static final fun MediaRouteButton (Landroidx/compose/ui/Modifier;Landroidx/mediarouter/media/MediaRouteSelector;Landroidx/compose/material3/IconButtonColors;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialogKt {
+	public static final fun MediaRouteChooserDialog (Landroidx/mediarouter/media/MediaRouteSelector;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialogKt {
+	public static final fun MediaRouteControllerDialog (Landroidx/mediarouter/media/MediaRouteSelector;Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/mediarouter-compose/build.gradle.kts
+++ b/mediarouter-compose/build.gradle.kts
@@ -65,8 +65,14 @@ android {
     }
 }
 
+kotlin {
+    explicitApi()
+}
+
 tasks.withType<Test>().configureEach {
     testLogging.exceptionFormat = TestExceptionFormat.FULL
+    // To disable explicit API mode for screenshot tests
+    kotlin.compilerOptions.freeCompilerArgs.add("-Xexplicit-api=disable")
 }
 
 val dokkaHtmlJar by tasks.registering(Jar::class) {

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButton.kt
@@ -51,7 +51,7 @@ import androidx.mediarouter.media.MediaRouteSelector
  * @param onDialogTypeChange The callback used to notify when the dialog type has changed.
  */
 @Composable
-fun MediaRouteButton(
+public fun MediaRouteButton(
     modifier: Modifier = Modifier,
     routeSelector: MediaRouteSelector = MediaRouteSelector.EMPTY,
     colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteButtonViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.update
 /**
  * The type of dialog to show.
  */
-enum class DialogType {
+public enum class DialogType {
     /**
      * Show the chooser dialog to select a route to connect to.
      */

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
@@ -63,7 +63,7 @@ import ch.srgssr.androidx.mediarouter.compose.MediaRouteChooserDialogViewModel.C
  * @see MediaRouteButton
  */
 @Composable
-fun MediaRouteChooserDialog(
+public fun MediaRouteChooserDialog(
     routeSelector: MediaRouteSelector,
     modifier: Modifier = Modifier,
     title: String? = null,

--- a/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
+++ b/mediarouter-compose/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteControllerDialog.kt
@@ -64,7 +64,7 @@ import coil3.compose.AsyncImagePainter
  * @see MediaRouteButton
  */
 @Composable
-fun MediaRouteControllerDialog(
+public fun MediaRouteControllerDialog(
     routeSelector: MediaRouteSelector,
     modifier: Modifier = Modifier,
     volumeControlEnabled: Boolean = true,


### PR DESCRIPTION
## Description

This PR enforces some good practices for Kotlin libraries. The complete guide is available on [Kotlin's website](https://kotlinlang.org/docs/api-guidelines-introduction.html).

## Changes made

- Enable [Explicit API mode](https://kotlinlang.org/docs/api-guidelines-simplicity.html#use-explicit-api-mode). This forces us to declare the visibility of every member, as well as the type of public members.
- Add [Binary Compatibility Validator](https://kotlinlang.org/docs/api-guidelines-backward-compatibility.html#use-the-binary-compatibility-validator). This generates a dump of the library's public API and complains when it changes.
- Update the GitHub Workflow to check API dumps and update them if needed.
- Fix explicit mode errors.